### PR TITLE
모든 요청 허용 spring security config 클래스 추가

### DIFF
--- a/kupica/src/main/java/org/nightdivers/kupica/config/SecurityConfig.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package org.nightdivers.kupica.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import jakarta.servlet.DispatcherType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(request -> request
+                        .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+                        .anyRequest().permitAll()
+                )
+                .formLogin(withDefaults())
+                .logout(withDefaults())
+                .build();
+    }
+}
+


### PR DESCRIPTION
초기 개발 동안 spring security 허가 관련된 불편을 막기 위해 모든 요청에 대해 허용하는 spring security config 클래스를 추가하였다.