### PR TITLE
민감정보 git submodule 로 분리하기

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kupica/store-submodule"]
+	path = kupica/store-submodule
+	url = git@github.com:Unagi-zoso/kupica-credential-store.git

--- a/kupica/.gitignore
+++ b/kupica/.gitignore
@@ -217,4 +217,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/gradle,intellij+all,java,kotlin,windows,macos
 
 # Private properties file
-src/main/resources/secret-info.properties
+src/main/resources/application-credential.yml

--- a/kupica/build.gradle
+++ b/kupica/build.gradle
@@ -47,3 +47,11 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+processResources.dependsOn('copyCredential')
+
+tasks.register('copyCredential', Copy) {
+    from './store-submodule'
+    include 'application*.yml'
+    into './src/main/resources'
+}

--- a/kupica/src/main/resources/application-database.yml
+++ b/kupica/src/main/resources/application-database.yml
@@ -4,7 +4,6 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 100
-  config.import: secret-info.properties
 
 ---
 spring:
@@ -13,9 +12,6 @@ spring:
       on-profile: production
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: # 미정
-    username: # 미정
-    password: # 미정
     hikari:
       maximum-pool-size: 5
       minimum-idle: 1
@@ -37,9 +33,6 @@ spring:
   config.activate.on-profile: development
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DATABASE_URL}
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
     hikari:
       maximum-pool-size: 2
       minimum-idle: 1

--- a/kupica/src/main/resources/application.yml
+++ b/kupica/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   profiles:
     include:
       - database
+      - credential
   servlet:
     multipart:
       max-file-size: 10MB


### PR DESCRIPTION
### 개요
기존 로컬 파일로 민감정보를 구성하던 방식은 원격 저장소에서 공유하기 힘든 문제가 있었다. 이러한 부분을 개선하기 위해 git submodule 을 사용한다.

### 작업내용
- git submodule 설정 파일 저장
- 관련 설정 추가
- 쓰지 않는 파일 및 설정 제거

### 추가 고려 사항

ref)
[git submodule](https://git-scm.com/book/ko/v2/Git-%EB%8F%84%EA%B5%AC-%EC%84%9C%EB%B8%8C%EB%AA%A8%EB%93%88)