### PR TITLE
github actions pr test workflow 추가 (#34 PR 로부터 이어졌음)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Grant execute permission for gradlew
         working-directory: ${{ env.working-directory }}
         run: chmod +x ./gradlew
+
+      - name: Copy credential info
+        working-directory: ${{ env.working-directory }}
+        run: ./gradlew copyCredential
  
       - name: Test with Gradle
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,29 @@
+name: PR Test
+ 
+on:
+  pull_request:
+    branches: [ main ] 
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    env:
+      working-directory: ./kupica
+
+    steps:
+      - uses: actions/checkout@v4
+ 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'      
+
+      - name: Grant execute permission for gradlew
+        working-directory: ${{ env.working-directory }}
+        run: chmod +x ./gradlew
+ 
+      - name: Test with Gradle
+        working-directory: ${{ env.working-directory }}
+        run: ./gradlew --info test
+

--- a/kupica/src/main/resources/application-database.yml
+++ b/kupica/src/main/resources/application-database.yml
@@ -79,4 +79,4 @@ spring:
 logging:
   level:
     org:
-      hibernate: trace
+      hibernate: debug


### PR DESCRIPTION
### 개요
#34 PR 에서 진행을 하다 기존 로컬파일로 민감정보를 다루던 방식은 Github 같은 원격 저장소에선 사용하기가 힘들어 
#37 PR 의 git submodule 로 구현하는 과정이 끼어들어 한 번 끊고 다시 PR 을 만들게 되었다.

Github PR 시 테스트 성공 여부를 알 수 있다면 좀 더 안정적으로 코드를 관리할 수 있을 것 같아 추가하려한다.

### 작업내용
github actions PR test workflow 추가

### 추가 고려 사항
캐싱이나 테스트 결과를 좀 더보기 좋게 하기 위해 고려해봐야할 것 같습니다.
