### PR TITLE
PR Test test report, caching 기능 추가

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,3 +31,9 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: ./gradlew --info test
 
+      - name: Publish Unit Test Results
+        working-directory: ${{ env.working-directory }}
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/**/*.xml

--- a/kupica/src/test/java/org/nightdivers/kupica/TestResultTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/TestResultTest.java
@@ -1,0 +1,34 @@
+package org.nightdivers.kupica;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+/*
+    PR Test 시 Test Report 가 잘 나오는지 확인하기 위한 항상 실패하는 테스트
+    Test Report 가 정상적으로 나오면 바로 삭제될 예정
+ */
+@ActiveProfiles("test")
+public class TestResultTest {
+
+    @DisplayName("PR Test 시 Test Report 가 잘 나오는지 확인하기 위한 항상 실패하는 테스트 1")
+    @Test
+    public void testAlwaysFailure1() {
+        assert false;
+    }
+
+    @DisplayName("PR Test 시 Test Report 가 잘 나오는지 확인하기 위한 항상 실패하는 테스트 2")
+    @Test
+    public void testAlwaysFailure2() {
+        int i = 5;
+        assert i == 4;
+    }
+
+    @DisplayName("PR Test 시 Test Report 가 잘 나오는지 확인하기 위한 항상 실패하는 테스트 3")
+    @Test
+    public void testAlwaysFailure3() {
+        List<Integer> integers = List.of(1, 2, 3, 4, 5);
+        assert integers.size() == 4;
+    }
+}


### PR DESCRIPTION
### 개요
지난 #33 PR 에서 test report, caching 기능을 추가하여 다시 PR 을 올리려한다.

### 작업내용
- test report 기능 추가

### 추가 고려 사항
다음 오픈소스를 사용하였습니다.
[EnricoMi/publish-unit-test-result-action@v1 MarketPlace](https://github.com/marketplace/actions/publish-test-results)
