### PR TITLE
repository 및 테스트 작성

### DIFF
--- a/kupica/src/main/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepository.java
@@ -1,7 +1,6 @@
 package org.nightdivers.kupica.domain.anonymoususer;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnonymousUserRepository extends JpaRepository<AnonymousUser, Long> {

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepository.java
@@ -1,0 +1,13 @@
+package org.nightdivers.kupica.domain.anonymoususer;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnonymousUserRepository extends JpaRepository<AnonymousUser, Long> {
+    List<AnonymousUser> findAllByNickname(String nickname);
+
+    List<AnonymousUser> findAllByIpAddress(String ipAddress);
+
+    List<AnonymousUser> findAllByNicknameAndIpAddress(String nickname, String ipAddress);
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/article/Article.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/article/Article.java
@@ -50,19 +50,12 @@ public class Article extends ModifiableBaseEntity {
         this.loginFlag = loginFlag;
     }
 
-    private static Article of(String caption,
-                             Member member,
-                             AnonymousUser anonymousUser,
-                             Boolean loginFlag) {
-        return new Article(caption, member, anonymousUser, loginFlag);
-    }
-
     public static Article createMemberArticle(String caption, Member member) {
-        return of(caption, member, null, true);
+        return new Article(caption, member, null, true);
     }
 
     public static Article createAnonymousArticle(String caption, AnonymousUser anonymousUser) {
-        return of(caption, null, anonymousUser, false);
+        return new Article(caption, null, anonymousUser, false);
     }
 
     @Override

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
@@ -1,37 +1,19 @@
 package org.nightdivers.kupica.domain.article;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    List<Article> findAllByOrderByCreatedDatetimeDesc();
+    Page<Article> findAllByOrderByCreatedDatetimeDesc(Pageable pageable);
 
-    List<Article> findAllByOrderByCreatedDatetimeAsc();
+    Page<Article> findAllByOrderByCreatedDatetimeAsc(Pageable pageable);
 
-    List<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(Long memberId);
+    Page<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(Pageable pageable, Long memberId);
 
-    List<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(Long memberId);
+    Page<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(Pageable pageable, Long memberId);
 
-    List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(String anonymousUser1);
+    Page<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(Pageable pageable, String anonymousUser1);
 
-    List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(String nickname);
-
-    @Query(value =
-            "SELECT a FROM Article a "
-                    + "LEFT JOIN a.member m "
-                    + "LEFT JOIN ArticleLike al ON al.article = a "
-                    + "GROUP BY a ORDER BY COUNT(al) DESC"
-    )
-    Page<Article> findArticlesOrderByLikesCountDesc(Pageable pageable);
-
-    @Query(value =
-            "SELECT a FROM Article a "
-                    + "LEFT JOIN a.member m "
-                    + "LEFT JOIN ArticleLike al ON al.article = a "
-                    + "GROUP BY a ORDER BY COUNT(al) ASC"
-    )
-    Page<Article> findArticlesOrderByLikesCountAsc(Pageable pageable);
+    Page<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(Pageable pageable, String nickname);
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
@@ -1,7 +1,10 @@
 package org.nightdivers.kupica.domain.article;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findAllByOrderByCreatedDatetimeDesc();
@@ -15,4 +18,20 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(String anonymousUser1);
 
     List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(String nickname);
+
+    @Query(value =
+            "SELECT a FROM Article a "
+                    + "LEFT JOIN a.member m "
+                    + "LEFT JOIN ArticleLike al ON al.article = a "
+                    + "GROUP BY a ORDER BY COUNT(al) DESC"
+    )
+    Page<Article> findArticlesOrderByLikesCountDesc(Pageable pageable);
+
+    @Query(value =
+            "SELECT a FROM Article a "
+                    + "LEFT JOIN a.member m "
+                    + "LEFT JOIN ArticleLike al ON al.article = a "
+                    + "GROUP BY a ORDER BY COUNT(al) ASC"
+    )
+    Page<Article> findArticlesOrderByLikesCountAsc(Pageable pageable);
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/article/ArticleRepository.java
@@ -1,0 +1,18 @@
+package org.nightdivers.kupica.domain.article;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    List<Article> findAllByOrderByCreatedDatetimeDesc();
+
+    List<Article> findAllByOrderByCreatedDatetimeAsc();
+
+    List<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(Long memberId);
+
+    List<Article> findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(Long memberId);
+
+    List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(String anonymousUser1);
+
+    List<Article> findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(String nickname);
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/articlehashtag/ArticleHashtagRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/articlehashtag/ArticleHashtagRepository.java
@@ -1,0 +1,9 @@
+package org.nightdivers.kupica.domain.articlehashtag;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleHashtagRepository extends JpaRepository<ArticleHashtag, Long> {
+    Page<ArticleHashtag> findByHashtagTagName(Pageable pageable, String tagName);
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLike.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLike.java
@@ -58,19 +58,12 @@ public class ArticleLike extends BaseTimeEntity {
         this.loginFlag = loginFlag;
     }
 
-    private static ArticleLike of(String ipAddress,
-                                  Member member,
-                                  Article article,
-                                  Boolean loginFlag) {
-        return new ArticleLike(ipAddress, member, article, loginFlag);
-    }
-
     public static ArticleLike createMemberArticleLike(Member member, Article article) {
-        return of(null, member, article, true);
+        return new ArticleLike(null, member, article, true);
     }
 
-    public static ArticleLike createAnonymousUserArticleLike(String ipAddress, Article article) {
-        return of(ipAddress, null, article, false);
+    public static ArticleLike createAnonymousArticleLike(String ipAddress, Article article) {
+        return new ArticleLike(ipAddress, null, article, false);
     }
 
     @Override

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepository.java
@@ -1,10 +1,35 @@
 package org.nightdivers.kupica.domain.articlelike;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
     List<ArticleLike> findAllByMemberId(Long memberId);
 
     List<ArticleLike> findAllByArticleId(Long articleId);
+
+    Long countByArticleId(Long articleId);
+
+    @Query( "SELECT al " +
+            "FROM ArticleLike al " +
+            "WHERE al.id IN ( " +
+                "SELECT MIN(al2.id) " +
+                "FROM ArticleLike al2 " +
+                "GROUP BY al2.article.id " +
+                "ORDER BY COUNT(al2.article.id) DESC)"
+    )
+    Page<ArticleLike> findArticleIdOrderByCountDesc(Pageable pageable);
+
+    @Query( "SELECT al " +
+            "FROM ArticleLike al " +
+            "WHERE al.id IN ( " +
+                "SELECT MIN(al2.id) " +
+                "FROM ArticleLike al2 " +
+                "GROUP BY al2.article.id " +
+                "ORDER BY COUNT(al2.article.id) ASC)"
+    )
+    Page<ArticleLike> findArticleIdOrderByCountAsc(Pageable pageable);
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepository.java
@@ -1,0 +1,10 @@
+package org.nightdivers.kupica.domain.articlelike;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
+    List<ArticleLike> findAllByMemberId(Long memberId);
+
+    List<ArticleLike> findAllByArticleId(Long articleId);
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/comment/Comment.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/comment/Comment.java
@@ -76,7 +76,7 @@ public class Comment extends ModifiableBaseEntity {
         return of(content, null, null, member, article, true);
     }
 
-    public static Comment createAnonymousComment(String content, AnonymousUser anonymousUser, Article article) {
+    public static Comment createAnonymousUserComment(String content, AnonymousUser anonymousUser, Article article) {
         return of(content, null, anonymousUser, null, article, false);
     }
 
@@ -105,5 +105,9 @@ public class Comment extends ModifiableBaseEntity {
     @Override
     public int hashCode() {
         return 31 * Objects.hashCode(this.getId());
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
     }
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/comment/CommentRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/comment/CommentRepository.java
@@ -1,0 +1,20 @@
+package org.nightdivers.kupica.domain.comment;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByArticleId(Long id);
+
+    List<Comment> findAllByMemberId(Long id);
+
+    List<Comment> findAllByMemberNickname(String nickname);
+
+    List<Comment> findAllByArticleIdAndMemberId(Long articleId, Long memberId);
+
+    List<Comment> findAllByArticleIdAndMemberNickname(Long id, String nickname);
+
+    List<Comment> findAllByAnonymousUserNickname(String nickname);
+
+    List<Comment> findAllByArticleIdAndAnonymousUserNickname(Long id, String nickname);
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/Hashtag.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/Hashtag.java
@@ -52,4 +52,8 @@ public class Hashtag extends ModifiableBaseEntity {
     }
 
     public final static int MAX_TAG_NAME_WITH_HASH_LENGTH = 26;
+
+    public void changeTagName(String tagName) {
+        this.tagName = validateTagName(tagName);
+    }
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/Hashtag.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/Hashtag.java
@@ -1,5 +1,7 @@
 package org.nightdivers.kupica.domain.hashtag;
 
+import static org.nightdivers.kupica.domain.hashtag.HashtagValidator.validateTagName;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,13 +19,13 @@ public class Hashtag extends ModifiableBaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="tag_name", nullable = false, unique = true, length = 26)
+    @Column(name="tag_name", nullable = false, unique = true, length = MAX_TAG_NAME_WITH_HASH_LENGTH)
     private String tagName;
 
     protected Hashtag() {}
 
     private Hashtag(String tagName) {
-        this.tagName = tagName;
+        this.tagName = validateTagName(tagName);
     }
 
     public static Hashtag of(String tagName) {
@@ -48,4 +50,6 @@ public class Hashtag extends ModifiableBaseEntity {
     public int hashCode() {
         return 31 * Objects.hashCode(this.getId());
     }
+
+    public final static int MAX_TAG_NAME_WITH_HASH_LENGTH = 26;
 }

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/HashtagRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/HashtagRepository.java
@@ -1,0 +1,6 @@
+package org.nightdivers.kupica.domain.hashtag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/HashtagValidator.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/hashtag/HashtagValidator.java
@@ -1,0 +1,44 @@
+package org.nightdivers.kupica.domain.hashtag;
+
+import static org.nightdivers.kupica.domain.hashtag.Hashtag.MAX_TAG_NAME_WITH_HASH_LENGTH;
+
+public class HashtagValidator {
+    public static String validateTagName(String tagName) {
+        if (tagName == null || tagName.isEmpty()) {
+            throw new IllegalArgumentException("Tag name must not be empty");
+        }
+
+        tagName = "#" + eraseContinuousHash(tagName);
+
+        if (tagName.length() < 2) {
+            throw new IllegalArgumentException("Tag name must not be empty");
+        }
+
+        if (tagName.length() > MAX_TAG_NAME_WITH_HASH_LENGTH) {
+            throw new IllegalArgumentException("Tag name must not exceed " + MAX_TAG_NAME_WITH_HASH_LENGTH + " characters");
+        }
+
+        return tagName;
+    }
+
+    private static int returnContinuousLastHashIndex(String tagName) {
+        int continuousLastHashIndex = -1;
+        for (int i = 0; i < tagName.length(); i++) {
+            if (tagName.charAt(i) != '#') {
+                break;
+            }
+            continuousLastHashIndex = i;
+
+        }
+        return continuousLastHashIndex;
+    }
+
+    private static String eraseContinuousHash(String tagName) {
+        int continuousLastHashIndex = returnContinuousLastHashIndex(tagName);
+        if (continuousLastHashIndex == -1) {
+            return tagName;
+        }
+
+        return tagName.substring(continuousLastHashIndex + 1);
+    }
+}

--- a/kupica/src/main/java/org/nightdivers/kupica/domain/photodownloadsource/PhotoDownloadSourceRepository.java
+++ b/kupica/src/main/java/org/nightdivers/kupica/domain/photodownloadsource/PhotoDownloadSourceRepository.java
@@ -1,0 +1,12 @@
+package org.nightdivers.kupica.domain.photodownloadsource;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoDownloadSourceRepository extends JpaRepository<PhotoDownloadSource, Long> {
+    List<PhotoDownloadSource> findByArticleId(long articleId);
+    
+    Page<PhotoDownloadSource> findByArticleId(Pageable pageable, long articleId);
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepositoryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.DUPLICATED_TEST_ANONYMOUS_COUNT;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_NICKNAME;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PW;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_NICKNAME;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_ID;
@@ -90,9 +90,11 @@ class AnonymousUserRepositoryTest {
     void givenDuplicatedAnonymousUsers_whenFindAllByNicknameAndIpAddress_thenSuccess() {
         // given
         // 테스트 익명 사용자 1 의 닉네임 과 테스트 익명 사용자 2 의 ip address 가 일치하는 익명 사용자 생성
-        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_1_NICKNAME, TEST_ANONYMOUS_USER_1_PASSWORD, TEST_ANONYMOUS_USER_2_IP_ADDRESS));
+        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_1_NICKNAME,
+                TEST_ANONYMOUS_USER_1_PW, TEST_ANONYMOUS_USER_2_IP_ADDRESS));
         // 테스트 익명 사용자 2 의 닉네임 과 테스트 익명 사용자 1 의 ip address 가 일치하는 익명 사용자 생성
-        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_2_NICKNAME, TEST_ANONYMOUS_USER_1_PASSWORD, TEST_ANONYMOUS_USER_1_IP_ADDRESS));
+        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_2_NICKNAME,
+                TEST_ANONYMOUS_USER_1_PW, TEST_ANONYMOUS_USER_1_IP_ADDRESS));
 
         // when
         List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByNicknameAndIpAddress(TEST_ANONYMOUS_USER_1_NICKNAME, TEST_ANONYMOUS_USER_1_IP_ADDRESS);

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/anonymoususer/AnonymousUserRepositoryTest.java
@@ -1,0 +1,162 @@
+package org.nightdivers.kupica.domain.anonymoususer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.DUPLICATED_TEST_ANONYMOUS_COUNT;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_ID;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_NICKNAME;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.nightdivers.kupica.support.factory.AnonymousUserFactory;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class AnonymousUserRepositoryTest {
+    private final AnonymousUserRepository anonymousUserRepository;
+
+    List<AnonymousUser> givenDuplicatedAnonymousUsers;
+
+    @BeforeEach
+    void setUp() {
+        givenDuplicatedAnonymousUsers = anonymousUserRepository.saveAll(
+                AnonymousUserFactory.createDuplicatedAnonymousUsers(AnonymousUserFactory::createTestAnonymousUser1, DUPLICATED_TEST_ANONYMOUS_COUNT)
+        );
+    }
+
+    /* 익명 사용자 목록 조회 */
+    @DisplayName("nickname 과 일치하는 익명 사용자 목록 조회 - [성공]")
+    @Test
+    void givenDuplicatedAnonymousUsers_whenFindAllByNickname_thenSuccess() {
+        // given
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByNickname(givenDuplicatedAnonymousUsers.getFirst().getNickname());
+
+        // then
+        assertThat(actualAnonymousUsers).containsAll(givenDuplicatedAnonymousUsers);
+        assertThat(actualAnonymousUsers.size()).isGreaterThanOrEqualTo(DUPLICATED_TEST_ANONYMOUS_COUNT);
+    }
+
+    @DisplayName("nickname 과 일치하는 익명 사용자 목록 조회 - [실패 : 일치하는 nickname 없음]")
+    @Test
+    void givenDuplicatedAnonymousUsers_whenFindAllByNickname_thenEmpty() {
+        // given
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByNickname(TEST_INVALID_ANONYMOUS_USER_NICKNAME);
+
+        // then
+        assertThat(actualAnonymousUsers).isEmpty();
+    }
+
+    @DisplayName("ip address 와 일치하는 익명 사용자 목록 조회 - [성공]")
+    @Test
+    void givenDuplicatedAnonymousUsers_whenFindAllByIpAddress_thenSuccess() {
+        // given
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByIpAddress(givenDuplicatedAnonymousUsers.getFirst().getIpAddress());
+
+        // then
+        assertThat(actualAnonymousUsers).containsAll(givenDuplicatedAnonymousUsers);
+        assertThat(actualAnonymousUsers.size()).isGreaterThanOrEqualTo(DUPLICATED_TEST_ANONYMOUS_COUNT);
+    }
+
+    @DisplayName("ip address 와 일치하는 익명 사용자 목록 조회 - [실패 : 일치하는 익명 사용자 없음]")
+    @Test
+    void givenDuplicatedAnonymousUsers_whenFindAllByIpAddress_thenEmpty() {
+        // given
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByIpAddress(TEST_INVALID_ANONYMOUS_USER_NICKNAME);
+
+        // then
+        assertThat(actualAnonymousUsers).isEmpty();
+    }
+
+    @DisplayName("nickname 과 ip address 와 일치하는 익명 사용자 목록 조회 - [성공]")
+    @Test
+    void givenDuplicatedAnonymousUsers_whenFindAllByNicknameAndIpAddress_thenSuccess() {
+        // given
+        // 테스트 익명 사용자 1 의 닉네임 과 테스트 익명 사용자 2 의 ip address 가 일치하는 익명 사용자 생성
+        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_1_NICKNAME, TEST_ANONYMOUS_USER_1_PASSWORD, TEST_ANONYMOUS_USER_2_IP_ADDRESS));
+        // 테스트 익명 사용자 2 의 닉네임 과 테스트 익명 사용자 1 의 ip address 가 일치하는 익명 사용자 생성
+        anonymousUserRepository.save(AnonymousUserFactory.createCustomAnonymousUsers(TEST_ANONYMOUS_USER_2_NICKNAME, TEST_ANONYMOUS_USER_1_PASSWORD, TEST_ANONYMOUS_USER_1_IP_ADDRESS));
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAllByNicknameAndIpAddress(TEST_ANONYMOUS_USER_1_NICKNAME, TEST_ANONYMOUS_USER_1_IP_ADDRESS);
+
+        // then
+        assertThat(actualAnonymousUsers).containsAll(givenDuplicatedAnonymousUsers);
+        assertThat(actualAnonymousUsers.size()).isEqualTo(DUPLICATED_TEST_ANONYMOUS_COUNT);
+    }
+
+    @DisplayName("모든 익명 사용자 조회 - [성공]")
+    @Test
+    void givenAnonymousUsers_whenFindAll_thenSuccess() {
+        // given
+
+        // when
+        List<AnonymousUser> actualAnonymousUsers = anonymousUserRepository.findAll();
+
+        // then
+        assertThat(actualAnonymousUsers).containsAll(givenDuplicatedAnonymousUsers);
+        assertThat(actualAnonymousUsers.size()).isGreaterThan(DUPLICATED_TEST_ANONYMOUS_COUNT);
+    }
+
+
+    /* 익명 사용자 등록 */
+    @DisplayName("익명 사용자 등록 - [성공]")
+    @Test
+    void givenAnonymousUser_whenSave_thenSuccess() {
+        // given
+        AnonymousUser expected = AnonymousUserFactory.createTestAnonymousUser3();
+
+        // when
+        AnonymousUser actual = anonymousUserRepository.save(expected);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+
+    /* 익명 사용자 삭제 */
+    @DisplayName("익명 사용자 삭제 - [성공]")
+    @Test
+    void givenAnonymousUser_whenDelete_thenSuccess() {
+        // given
+        AnonymousUser givenAnonymousUser = givenDuplicatedAnonymousUsers.getFirst();
+
+        // when
+        anonymousUserRepository.delete(givenAnonymousUser);
+
+        // then
+        assertThatThrownBy(() -> anonymousUserRepository.findById(givenAnonymousUser.getId()).orElseThrow(NoSuchElementException::new))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @DisplayName("익명 사용자 삭제 - [실패 : 존재하지 않는 익명 사용자]")
+    @Test
+    void givenAnonymousUser_whenDelete_thenNotEffect() {
+        // given
+        int previousSize = anonymousUserRepository.findAll().size();
+
+        // when
+        anonymousUserRepository.deleteById(TEST_INVALID_ANONYMOUS_USER_ID);
+        int currentSize = anonymousUserRepository.findAll().size();
+
+        // then
+        assertThat(currentSize).isEqualTo(previousSize);
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
@@ -1,0 +1,346 @@
+package org.nightdivers.kupica.domain.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_NICKNAME;
+import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
+import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.PropertyValueException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUserRepository;
+import org.nightdivers.kupica.domain.member.Member;
+import org.nightdivers.kupica.domain.member.MemberRepository;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.nightdivers.kupica.support.factory.AnonymousUserFactory;
+import org.nightdivers.kupica.support.factory.ArticleFactory;
+import org.nightdivers.kupica.support.factory.MemberFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class ArticleRepositoryTest {
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+    private final AnonymousUserRepository anonymousUserRepository;
+    private final EntityManager entityManager;
+
+    // 실제론 테스트 시 test.resource.sql.data-h2.sql 에서 만들어 둔 테스트 셋이 더 존재합니다.
+    int givenTestDataSetSize = 6;
+
+    Article givenMemberArticle1;
+    Article givenMemberArticle2;
+    Article givenMemberArticle3;
+
+    Article givenAnonymousArticle1;
+    Article givenAnonymousArticle2;
+    Article givenAnonymousArticle3;
+
+    Member givenMember1;
+
+    AnonymousUser givenAnonymousUser1;
+
+    @BeforeEach
+    void setUp() {
+        givenMember1 = memberRepository.save(MemberFactory.createTestMember1());
+
+        givenMemberArticle1 = ArticleFactory.createTestMemberArticle1();
+        givenMemberArticle2 = ArticleFactory.createTestMemberArticle2();
+        givenMemberArticle3 = ArticleFactory.createTestMemberArticle3();
+
+        givenAnonymousUser1 = anonymousUserRepository.save(AnonymousUserFactory.createTestAnonymousUser1());
+
+        givenAnonymousArticle1 = ArticleFactory.createTestAnonymousArticle1();
+        givenAnonymousArticle2 = ArticleFactory.createTestAnonymousArticle2();
+        givenAnonymousArticle3 = ArticleFactory.createTestAnonymousArticle3();
+
+        articleRepository.saveAll(List.of(givenMemberArticle1, givenMemberArticle2, givenMemberArticle3,
+                givenAnonymousArticle1, givenAnonymousArticle2, givenAnonymousArticle3));
+    }
+
+    /* 게시글 단일 조회 */
+    @DisplayName("게시글 단일 조회 - [성공]")
+    @Test
+    void givenArticle_whenFindById_thenSuccess() {
+        // given
+
+        // when
+        Article actualMemberArticle = articleRepository.findById(givenMemberArticle1.getId()).orElseThrow(NoSuchElementException::new);
+        Article actualAnonymousArticle = articleRepository.findById(givenAnonymousArticle1.getId()).orElseThrow(NoSuchElementException::new);
+
+        // then
+        assertAll(
+                () -> assertThat(actualMemberArticle).isEqualTo(givenMemberArticle1),
+                () -> assertThat(actualAnonymousArticle).isEqualTo(givenAnonymousArticle1)
+        );
+    }
+
+    @DisplayName("게시글 단일 조회 - [실패 : 존재하지 않는 게시글]")
+    @Test
+    void givenArticle_whenFindById_thenFail() {
+        // given
+
+        // when & then
+        assertAll(
+                () -> assertThatThrownBy(() -> articleRepository.findById(TEST_INVALID_ARTICLE_ID).orElseThrow(NoSuchElementException::new))
+                        .isInstanceOf(NoSuchElementException.class),
+                () -> assertThatThrownBy(() -> articleRepository.findById(TEST_INVALID_ARTICLE_ID).orElseThrow(NoSuchElementException::new))
+                        .isInstanceOf(NoSuchElementException.class)
+        );
+    }
+
+
+    /* 게시글 목록 조회 */
+    @DisplayName("게시글 목록 조회 - [성공]")
+    @Test
+    void givenArticles_whenFindAll_thenSuccess() {
+        // given
+
+        // when
+        List<Article> actualArticles = articleRepository.findAll();
+
+        // then
+        assertThat(actualArticles).contains(givenMemberArticle1, givenMemberArticle2, givenMemberArticle3,
+                givenAnonymousArticle1, givenAnonymousArticle2, givenAnonymousArticle3);
+    }
+
+    @DisplayName("최근 등록된 순서대로 게시글 목록 조회 - [성공]")
+    @Test
+    void givenArticles_whenFindAllByOrderByCreatedDatetimeDesc_thenSuccess() {
+        // given
+
+        // when
+        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeDesc();
+
+        // then
+        assertThat(actualArticles.subList(0, givenTestDataSetSize)).containsExactly(givenAnonymousArticle3, givenAnonymousArticle2, givenAnonymousArticle1,
+                givenMemberArticle3, givenMemberArticle2,  givenMemberArticle1);
+    }
+
+    @DisplayName("등록된지 오래된 순서대로 게시글 목록 조회 - [성공]")
+    @Test
+    void givenArticles_whenFindAllByOrderByCreatedDatetimeAsc_thenSuccess() {
+        // given
+
+        // when
+        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeAsc();
+
+        // then
+        assertThat(actualArticles.subList(actualArticles.size() - givenTestDataSetSize, actualArticles.size())).containsExactly(givenMemberArticle1, givenMemberArticle2, givenMemberArticle3,
+                givenAnonymousArticle1, givenAnonymousArticle2, givenAnonymousArticle3);
+    }
+
+    @DisplayName("member id 와 일치하며 최근 등록된 순서대로 member 게시글 목록 조회 - [성공]")
+    @Test
+    void givenMemberId_whenFindAllByMemberIdOrderByCreatedDatetimeDesc_thenSuccess() {
+        // given
+        Article givenMemberArticle1ByMember1 = ArticleFactory.createCustomMemberArticle("memberArticle2ByMember1", givenMember1);
+        Article givenMemberArticle2ByMember1 = ArticleFactory.createCustomMemberArticle("memberArticle3ByMember1", givenMember1);
+        articleRepository.saveAll(List.of(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1));
+
+        // when
+        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(givenMemberArticle1ByMember1.getMember().getId());
+
+        // then
+        assertThat(actualArticles).containsExactly(givenMemberArticle2ByMember1, givenMemberArticle1ByMember1);
+    }
+
+    @DisplayName("member id 와 일치하며 최근 등록된 순서대로 member 게시글 목록 조회 - [실패 : 존재하지 않는 회원]")
+    @Test
+    void givenMemberId_whenFindAllByMemberIdOrderByCreatedDatetimeDesc_thenEmpty() {
+        // given
+
+        // when & then
+        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(TEST_INVALID_MEMBER_ID)).isEmpty();
+    }
+
+    @DisplayName("member id 와 일치하며 등록된지 오래된 순서대로 member 게시글 목록 조회 - [성공]")
+    @Test
+    void givenMemberId_whenFindAllByMemberIdOrderByCreatedDatetimeAsc_thenSuccess() {
+        // given
+        Article givenMemberArticle1ByMember1 = ArticleFactory.createCustomMemberArticle("memberArticle2ByMember1", givenMember1);
+        Article givenMemberArticle2ByMember1 = ArticleFactory.createCustomMemberArticle("memberArticle3ByMember1", givenMember1);
+        articleRepository.saveAll(List.of(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1));
+
+        // when
+        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(givenMemberArticle1ByMember1.getMember().getId());
+
+        // then
+        assertThat(actualArticles).containsExactly(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1);
+    }
+
+    @DisplayName("member id 와 일치하며 등록된지 오래된 순서대로 member 게시글 목록 조회 - [실패 : 존재하지 않는 회원]")
+    @Test
+    void givenMemberId_whenFindAllByMemberIdOrderByCreatedDatetimeAsc_thenEmpty() {
+        // given
+
+        // when & then
+        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(TEST_INVALID_MEMBER_ID)).isEmpty();
+    }
+
+    @DisplayName("anonymousUser nickname 과 일치하며 최근 등록된 순서대로 anonymous 게시글 목록 조회 - [성공]")
+    @Test
+    void givenAnonymousUserNickname_whenFindAllByAnonymousUserNicknameOrderByCreatedDatetimeDesc_thenSuccess() {
+        // given
+        Article givenAnonymousArticle1ByAnonymousUser1 = ArticleFactory.createCustomAnonymousArticle("anonymousArticle2ByAnonymousUser1", givenAnonymousUser1);
+        Article givenAnonymousArticle2ByAnonymousUser1 = ArticleFactory.createCustomAnonymousArticle("anonymousArticle3ByAnonymousUser1", givenAnonymousUser1);
+        articleRepository.saveAll(List.of(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1));
+
+        // when
+        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(givenAnonymousUser1.getNickname());
+
+        // then
+        assertThat(actualArticles).containsExactly(givenAnonymousArticle2ByAnonymousUser1, givenAnonymousArticle1ByAnonymousUser1);
+    }
+
+    @DisplayName("anonymousUser nickname 과 일치하며 최근 등록된 순서대로 anonymous 게시글 목록 조회 - [실패 : 존재하지 않는 익명 사용자]")
+    @Test
+    void givenAnonymousUserNickname_whenFindAllByAnonymousUserNicknameOrderByCreatedDatetimeDesc_thenEmpty() {
+        // given
+
+        // when & then
+        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc("invalidAnonymousUser")).isEmpty();
+    }
+
+    @DisplayName("anonymousUser nickname 과 일치하며 등록된지 오래된 순서대로 anonymous 게시글 목록 조회 - [성공]")
+    @Test
+    void givenAnonymousUserNickname_whenFindAllByAnonymousUserNicknameOrderByCreatedDatetimeAsc_thenSuccess() {
+        // given
+        Article givenAnonymousArticle1ByAnonymousUser1 = ArticleFactory.createCustomAnonymousArticle("anonymousArticle2ByAnonymousUser1", givenAnonymousUser1);
+        Article givenAnonymousArticle2ByAnonymousUser1 = ArticleFactory.createCustomAnonymousArticle("anonymousArticle3ByAnonymousUser1", givenAnonymousUser1);
+        articleRepository.saveAll(List.of(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1));
+
+        // when
+        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(givenAnonymousUser1.getNickname());
+
+        // then
+        assertThat(actualArticles).containsExactly(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1);
+    }
+
+    @DisplayName("anonymousUser nickname 과 일치하며 등록된지 오래된 순서대로 anonymous 게시글 목록 조회 - [실패 : 존재하지 않는 익명 사용자]")
+    @Test
+    void givenAnonymousUserNickname_whenFindAllByAnonymousUserNicknameOrderByCreatedDatetimeAsc_thenEmpty() {
+        // given
+
+        // when & then
+        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(TEST_INVALID_ANONYMOUS_USER_NICKNAME)).isEmpty();
+    }
+
+
+    /* 게시글 등록 */
+    @DisplayName("게시글 등록 - [성공]")
+    @Test
+    void givenArticle_whenSave_thenSuccess() {
+        // given
+        Article expectedMemberArticle = ArticleFactory.createTestMemberArticle4();
+        Article expectedAnonymousArticle = ArticleFactory.createTestAnonymousArticle4();
+
+        // when
+        Article actualMemberArticle = articleRepository.save(expectedMemberArticle);
+        Article actualAnonymousArticle = articleRepository.save(expectedAnonymousArticle);
+
+        // then
+        assertAll(
+                () -> assertThat(actualMemberArticle).isEqualTo(expectedMemberArticle),
+                () -> assertThat(actualAnonymousArticle).isEqualTo(expectedAnonymousArticle)
+        );
+    }
+
+    @DisplayName("게시글 등록 - [실패 : 게시글 제목이 없는 경우]")
+    @Test
+    void givenArticle_whenSave_thenFail() {
+        // given
+        Article expectedMemberArticle = ArticleFactory.createCustomMemberArticle(null, null);
+        Article expectedAnonymousArticle = ArticleFactory.createCustomAnonymousArticle(null, null);
+
+        // when & then
+        assertAll(
+                () -> assertThatThrownBy(() -> articleRepository.save(expectedMemberArticle))
+                        .isInstanceOf(DataIntegrityViolationException.class),
+                () -> assertThatThrownBy(() -> articleRepository.save(expectedAnonymousArticle))
+                        .isInstanceOf(DataIntegrityViolationException.class)
+        );
+    }
+
+
+    /* 게시글 수정 */
+    @DisplayName("게시글 본문 수정 - [성공]")
+    @Test
+    void givenArticle_whenChangeCaption_thenSuccess() {
+        // given
+        Article memberArticle = articleRepository.findById(givenMemberArticle1.getId()).orElseThrow(NoSuchElementException::new);
+        LocalDateTime prevMemberArticleUpdatedDatetime = memberArticle.getUpdatedDatetime();
+        Article anonymousArticle = articleRepository.findById(givenAnonymousArticle1.getId()).orElseThrow(NoSuchElementException::new);
+        LocalDateTime prevAnonymousArticleUpdatedDatetime = anonymousArticle.getUpdatedDatetime();
+
+        // when
+        memberArticle.changeCaption("newCaption");
+        anonymousArticle.changeCaption("newCaption");
+
+        entityManager.flush();
+
+        Article actualMemberArticle = articleRepository.findById(memberArticle.getId()).orElseThrow(NoSuchElementException::new);
+        Article actualAnonymousArticle = articleRepository.findById(anonymousArticle.getId()).orElseThrow(NoSuchElementException::new);
+
+        // then
+        assertAll(
+                () -> assertThat(actualMemberArticle.getCaption()).isEqualTo("newCaption"),
+                () -> assertThat(actualMemberArticle.getUpdatedDatetime()).isAfter(prevMemberArticleUpdatedDatetime),
+                () -> assertThat(actualAnonymousArticle.getCaption()).isEqualTo("newCaption"),
+                () -> assertThat(actualAnonymousArticle.getUpdatedDatetime()).isAfter(prevAnonymousArticleUpdatedDatetime)
+        );
+    }
+
+    @DisplayName("게시글 본문 수정 - [실패 : 게시글 제목이 없는 경우]")
+    @Test
+    void givenArticle_whenChangeCaption_thenThrowPropertyValueException() {
+        // given
+        Article memberArticle = articleRepository.findById(givenMemberArticle1.getId()).orElseThrow(NoSuchElementException::new);
+        Article anonymousArticle = articleRepository.findById(givenAnonymousArticle1.getId()).orElseThrow(NoSuchElementException::new);
+
+        // when
+        memberArticle.changeCaption(null);
+        anonymousArticle.changeCaption(null);
+
+        // then
+        assertThatThrownBy(entityManager::flush)
+                        .isInstanceOf(PropertyValueException.class);
+    }
+
+
+    /* 게시글 삭제 */
+    @DisplayName("게시글 삭제 - [성공]")
+    @Test
+    void givenArticle_whenDelete_thenSuccess() {
+        // given
+
+        // when
+        articleRepository.delete(givenMemberArticle1);
+        articleRepository.delete(givenAnonymousArticle1);
+
+        // then
+        assertThat(articleRepository.findAll()).doesNotContain(givenMemberArticle1, givenAnonymousArticle1);
+    }
+
+    @DisplayName("id 가 일치하는 게시글 삭제 - [성공]")
+    @Test
+    void givenArticleId_whenDeleteById_thenSuccess() {
+        // given
+
+        // when
+        articleRepository.deleteById(givenMemberArticle1.getId());
+        articleRepository.deleteById(givenAnonymousArticle1.getId());
+
+        // then
+        assertThat(articleRepository.findAll()).doesNotContain(givenMemberArticle1, givenAnonymousArticle1);
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
@@ -34,6 +34,10 @@ class ArticleRepositoryTest {
     private final AnonymousUserRepository anonymousUserRepository;
     private final EntityManager entityManager;
 
+    Member givenMember1;
+
+    AnonymousUser givenAnonymousUser1;
+
     // 실제론 테스트 시 test.resource.sql.data-h2.sql 에서 만들어 둔 테스트 셋이 더 존재합니다.
     int givenTestDataSetSize = 6;
 
@@ -44,10 +48,6 @@ class ArticleRepositoryTest {
     Article givenAnonymousArticle1;
     Article givenAnonymousArticle2;
     Article givenAnonymousArticle3;
-
-    Member givenMember1;
-
-    AnonymousUser givenAnonymousUser1;
 
     @BeforeEach
     void setUp() {

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/article/ArticleRepositoryTest.java
@@ -3,8 +3,6 @@ package org.nightdivers.kupica.domain.article;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.nightdivers.kupica.domain.articlelike.ArticleLike.createAnonymousArticleLike;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_IP_LIST;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_NICKNAME;
 import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
@@ -20,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
 import org.nightdivers.kupica.domain.anonymoususer.AnonymousUserRepository;
-import org.nightdivers.kupica.domain.articlelike.ArticleLikeRepository;
 import org.nightdivers.kupica.domain.member.Member;
 import org.nightdivers.kupica.domain.member.MemberRepository;
 import org.nightdivers.kupica.support.annotation.RepositoryTest;
@@ -36,7 +33,6 @@ class ArticleRepositoryTest {
     private final ArticleRepository articleRepository;
     private final MemberRepository memberRepository;
     private final AnonymousUserRepository anonymousUserRepository;
-    private final ArticleLikeRepository articleLikeRepository;
     private final EntityManager entityManager;
 
     Member givenMember1;
@@ -124,7 +120,7 @@ class ArticleRepositoryTest {
         // given
 
         // when
-        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeDesc();
+        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeDesc(PageRequest.of(0, givenTestDataSetSize)).getContent();
 
         // then
         assertThat(actualArticles.subList(0, givenTestDataSetSize)).containsExactly(givenAnonymousArticle3, givenAnonymousArticle2, givenAnonymousArticle1,
@@ -137,7 +133,7 @@ class ArticleRepositoryTest {
         // given
 
         // when
-        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeAsc();
+        List<Article> actualArticles = articleRepository.findAllByOrderByCreatedDatetimeAsc(PageRequest.of(0, 100)).getContent();
 
         // then
         assertThat(actualArticles.subList(actualArticles.size() - givenTestDataSetSize, actualArticles.size())).containsExactly(givenMemberArticle1, givenMemberArticle2, givenMemberArticle3,
@@ -153,7 +149,10 @@ class ArticleRepositoryTest {
         articleRepository.saveAll(List.of(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1));
 
         // when
-        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(givenMemberArticle1ByMember1.getMember().getId());
+        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(
+                PageRequest.of(0, givenTestDataSetSize),
+                givenMemberArticle1ByMember1.getMember().getId())
+                .getContent();
 
         // then
         assertThat(actualArticles).containsExactly(givenMemberArticle2ByMember1, givenMemberArticle1ByMember1);
@@ -165,7 +164,10 @@ class ArticleRepositoryTest {
         // given
 
         // when & then
-        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(TEST_INVALID_MEMBER_ID)).isEmpty();
+        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeDesc(
+                PageRequest.of(0, givenTestDataSetSize),
+                TEST_INVALID_MEMBER_ID))
+                .isEmpty();
     }
 
     @DisplayName("member id 와 일치하며 등록된지 오래된 순서대로 member 게시글 목록 조회 - [성공]")
@@ -177,7 +179,10 @@ class ArticleRepositoryTest {
         articleRepository.saveAll(List.of(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1));
 
         // when
-        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(givenMemberArticle1ByMember1.getMember().getId());
+        List<Article> actualArticles = articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(
+                PageRequest.of(0, givenTestDataSetSize),
+                givenMemberArticle1ByMember1.getMember().getId())
+                .getContent();
 
         // then
         assertThat(actualArticles).containsExactly(givenMemberArticle1ByMember1, givenMemberArticle2ByMember1);
@@ -189,7 +194,10 @@ class ArticleRepositoryTest {
         // given
 
         // when & then
-        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(TEST_INVALID_MEMBER_ID)).isEmpty();
+        assertThat(articleRepository.findByMemberIdAndLoginFlagIsTrueOrderByCreatedDatetimeAsc(
+                PageRequest.of(0, givenTestDataSetSize),
+                TEST_INVALID_MEMBER_ID))
+                .isEmpty();
     }
 
     @DisplayName("anonymousUser nickname 과 일치하며 최근 등록된 순서대로 anonymous 게시글 목록 조회 - [성공]")
@@ -201,7 +209,10 @@ class ArticleRepositoryTest {
         articleRepository.saveAll(List.of(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1));
 
         // when
-        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(givenAnonymousUser1.getNickname());
+        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(
+                PageRequest.of(0, givenTestDataSetSize),
+                givenAnonymousUser1.getNickname())
+                .getContent();
 
         // then
         assertThat(actualArticles).containsExactly(givenAnonymousArticle2ByAnonymousUser1, givenAnonymousArticle1ByAnonymousUser1);
@@ -213,7 +224,10 @@ class ArticleRepositoryTest {
         // given
 
         // when & then
-        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc("invalidAnonymousUser")).isEmpty();
+        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeDesc(
+                PageRequest.of(0, givenTestDataSetSize),
+                "invalidAnonymousUser"))
+                .isEmpty();
     }
 
     @DisplayName("anonymousUser nickname 과 일치하며 등록된지 오래된 순서대로 anonymous 게시글 목록 조회 - [성공]")
@@ -225,7 +239,10 @@ class ArticleRepositoryTest {
         articleRepository.saveAll(List.of(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1));
 
         // when
-        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(givenAnonymousUser1.getNickname());
+        List<Article> actualArticles = articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(
+                PageRequest.of(0, givenTestDataSetSize),
+                givenAnonymousUser1.getNickname())
+                .getContent();
 
         // then
         assertThat(actualArticles).containsExactly(givenAnonymousArticle1ByAnonymousUser1, givenAnonymousArticle2ByAnonymousUser1);
@@ -237,49 +254,10 @@ class ArticleRepositoryTest {
         // given
 
         // when & then
-        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(TEST_INVALID_ANONYMOUS_USER_NICKNAME)).isEmpty();
-    }
-
-    @DisplayName("좋아요 수가 많은 순서대로 게시글 목록 조회 - [성공]")
-    @Test
-    void givenArticlesAndArticleLikes_whenFindAllByOrderByLikeCountDesc_thenSuccess() {
-        // given
-        articleLikeRepository.deleteAll();
-
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size())
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle1)));
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-1)
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle2)));
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-2)
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle3)));
-
-        // when
-        List<Article> actualArticles = articleRepository.findArticlesOrderByLikesCountDesc(PageRequest.of(0, 3)).getContent();
-
-        // then
-        assertThat(actualArticles).containsExactly(givenAnonymousArticle1, givenAnonymousArticle2, givenAnonymousArticle3);
-    }
-
-    @DisplayName("좋아요 수가 적은 순서대로 게시글 목록 조회 - [성공]")
-    @Test
-    void givenArticlesAndArticleLikes_whenFindAllByOrderByLikeCountAsc_thenSuccess() {
-        // given
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size())
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle1)));
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-1)
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle2)));
-        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-2)
-                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenAnonymousArticle3)));
-
-        // when
-        List<Article> actualArticles = articleRepository.findArticlesOrderByLikesCountAsc(PageRequest.of(0, 50)).getContent();
-
-        // then
-        assertAll(
-                () -> assertThat(actualArticles.getLast()).isEqualTo(givenAnonymousArticle1),
-                () -> assertThat(actualArticles.get(actualArticles.size()-2)).isEqualTo(givenAnonymousArticle2),
-                () -> assertThat(actualArticles.get(actualArticles.size()-3)).isEqualTo(givenAnonymousArticle3)
-        );
+        assertThat(articleRepository.findByAnonymousUserNicknameAndLoginFlagIsFalseOrderByCreatedDatetimeAsc(
+                PageRequest.of(0, givenTestDataSetSize),
+                TEST_INVALID_ANONYMOUS_USER_NICKNAME))
+                .isEmpty();
     }
 
 

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/articlehashtag/ArticleHashtagRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/articlehashtag/ArticleHashtagRepositoryTest.java
@@ -1,0 +1,45 @@
+package org.nightdivers.kupica.domain.articlehashtag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_INVALID_TAG_NAME;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_VALID_TAG_NAME;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.springframework.data.domain.PageRequest;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class ArticleHashtagRepositoryTest {
+    private final ArticleHashtagRepository articleHashtagRepository;
+
+    /* Article Hashtag 조회 */
+    @DisplayName("Hashtag 와 일치하는 Article 페이지로 조회 - [성공]")
+    @Test
+    void givenHashtag_whenFindArticleByHashtag_thenReturnArticlePage() {
+        // given
+
+
+        // when
+        List<ArticleHashtag> articleHashtags = articleHashtagRepository.findByHashtagTagName(PageRequest.of(0, 5), TEST_VALID_TAG_NAME).getContent();
+
+        // then
+        assertThat(articleHashtags).isNotEmpty();
+    }
+
+    @DisplayName("Hashtag 와 일치하는 Article 페이지로 조회 - [실패 : Hashtag 미존재]")
+    @Test
+    void givenHashtag_whenFindArticleByHashtag_thenEmpty() {
+        // given
+
+        // when
+        List<ArticleHashtag> articleHashtags = articleHashtagRepository.findByHashtagTagName(PageRequest.of(0, 5),
+                TEST_INVALID_TAG_NAME).getContent();
+
+        // then
+        assertThat(articleHashtags).isEmpty();
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepositoryTest.java
@@ -1,0 +1,191 @@
+package org.nightdivers.kupica.domain.articlelike;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.nightdivers.kupica.domain.articlelike.ArticleLike.createAnonymousArticleLike;
+import static org.nightdivers.kupica.domain.articlelike.ArticleLike.createMemberArticleLike;
+import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
+import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
+import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser1;
+import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser2;
+import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser3;
+import static org.nightdivers.kupica.support.factory.ArticleFactory.createTestMemberArticle1;
+import static org.nightdivers.kupica.support.factory.ArticleFactory.createTestMemberArticle2;
+import static org.nightdivers.kupica.support.factory.ArticleFactory.createTestMemberArticle3;
+import static org.nightdivers.kupica.support.factory.MemberFactory.createTestMember1;
+import static org.nightdivers.kupica.support.factory.MemberFactory.createTestMember2;
+import static org.nightdivers.kupica.support.factory.MemberFactory.createTestMember3;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUserRepository;
+import org.nightdivers.kupica.domain.article.Article;
+import org.nightdivers.kupica.domain.article.ArticleRepository;
+import org.nightdivers.kupica.domain.member.Member;
+import org.nightdivers.kupica.domain.member.MemberRepository;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class ArticleLikeRepositoryTest {
+    private final ArticleLikeRepository articleLikeRepository;
+    private final MemberRepository memberRepository;
+    private final AnonymousUserRepository anonymousUserRepository;
+    private final ArticleRepository articleRepository;
+
+    Member givenMember1;
+    Member givenMember2;
+
+    AnonymousUser givenAnonymousUser1;
+    AnonymousUser givenAnonymousUser2;
+
+    Article givenArticle1;
+    Article givenArticle2;
+
+    ArticleLike givenArticleLike1;
+    ArticleLike givenArticleLike2;
+    ArticleLike givenArticleLike3;
+    ArticleLike givenArticleLike4;
+    ArticleLike givenArticleLike5;
+    ArticleLike givenArticleLike6;
+
+    @BeforeEach
+    void setUp() {
+        givenMember1 = memberRepository.save(createTestMember1());
+        givenMember2 = memberRepository.save(createTestMember2());
+
+        givenAnonymousUser1 = anonymousUserRepository.save(createTestAnonymousUser1());
+        givenAnonymousUser2 = anonymousUserRepository.save(createTestAnonymousUser2());
+
+        givenArticle1 = articleRepository.save(createTestMemberArticle1());
+        givenArticle2 = articleRepository.save(createTestMemberArticle2());
+
+        givenArticleLike1 = articleLikeRepository.save(createMemberArticleLike(givenMember1, givenArticle1));
+        givenArticleLike2 = articleLikeRepository.save(createMemberArticleLike(givenMember1, givenArticle2));
+        givenArticleLike3 = articleLikeRepository.save(createMemberArticleLike(givenMember2, givenArticle1));
+        givenArticleLike5 = articleLikeRepository.save(createAnonymousArticleLike(givenAnonymousUser1.getIpAddress(), givenArticle1));
+        givenArticleLike4 = articleLikeRepository.save(createAnonymousArticleLike(givenAnonymousUser2.getIpAddress(), givenArticle2));
+        givenArticleLike6 = articleLikeRepository.save(createAnonymousArticleLike(givenAnonymousUser1.getIpAddress(), givenArticle2));
+    }
+
+    /* 좋아요 조회 */
+    @DisplayName("member id 와 일치하는 좋아요 조회 - [성공]")
+    @Test
+    void givenMemberId_whenFindAllByMemberId_thenReturnsArticleLikeList() {
+        // given
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByMemberId(givenMember1.getId());
+
+        // then
+        assertThat(articleLikeList).hasSize(2);
+    }
+
+    @DisplayName("member id 와 일치하는 좋아요 조회 - [실패 : 좋아요 없음]")
+    @Test
+    void givenValidMemberId_whenFindAllByMemberId_thenReturnsEmptyList() {
+        // given
+        Long memberId = memberRepository.save(createTestMember3()).getId();
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByMemberId(memberId);
+
+        // then
+        assertThat(articleLikeList).isEmpty();
+    }
+
+    @DisplayName("member id 와 일치하는 좋아요 조회 - [실패 : member id 없음]")
+    @Test
+    void givenInvalidMemberId_whenFindAllByMemberId_thenReturnsEmptyList() {
+        // given
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByMemberId(TEST_INVALID_MEMBER_ID);
+
+        // then
+        assertThat(articleLikeList).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하는 좋아요 조회 - [성공]")
+    @Test
+    void givenArticleId_whenFindAllByArticleId_thenReturnsArticleLikeList() {
+        // given
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByArticleId(givenArticle1.getId());
+
+        // then
+        assertThat(articleLikeList).hasSize(3);
+    }
+
+    @DisplayName("article id 와 일치하는 좋아요 조회 - [실패 : 좋아요 없음]")
+    @Test
+    void givenValidArticleId_whenFindAllByArticleId_thenReturnsEmptyList() {
+        // given
+        Long articleId = articleRepository.save(createTestMemberArticle3()).getId();
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByArticleId(articleId);
+
+        // then
+        assertThat(articleLikeList).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하는 좋아요 조회 - [실패 : article id 없음]")
+    @Test
+    void givenInvalidArticleId_whenFindAllByArticleId_thenReturnsEmptyList() {
+        // given
+
+        // when
+        List<ArticleLike> articleLikeList = articleLikeRepository.findAllByArticleId(TEST_INVALID_ARTICLE_ID);
+
+        // then
+        assertThat(articleLikeList).isEmpty();
+    }
+
+
+    /* 좋아요 생성 */
+    @DisplayName("member 좋아요 생성 - [성공]")
+    @Test
+    void givenMember_whenCreateMemberArticleLike_thenReturnsArticleLike() {
+        // given
+        Member member = memberRepository.save(createTestMember3());
+
+        // when
+        ArticleLike actualArticleLike = articleLikeRepository.save(createMemberArticleLike(member, givenArticle1));
+
+        // then
+        assertThat(actualArticleLike).isNotNull();
+    }
+
+    @DisplayName("anonymous user 좋아요 생성 - [성공]")
+    @Test
+    void givenAnonymousUser_whenCreateAnonymousArticleLike_thenReturnsArticleLike() {
+        // given
+        AnonymousUser anonymousUser = anonymousUserRepository.save(createTestAnonymousUser3());
+
+        // when
+        ArticleLike actualArticleLike = articleLikeRepository.save(createAnonymousArticleLike(anonymousUser.getIpAddress(), givenArticle1));
+
+        // then
+        assertThat(actualArticleLike).isNotNull();
+    }
+
+
+    /* 좋아요 삭제 */
+    @DisplayName("member 좋아요 삭제 - [성공]")
+    @Test
+    void givenMemberArticleLike_whenDelete_thenReturnsVoid() {
+        // given
+        ArticleLike articleLike = articleLikeRepository.save(createMemberArticleLike(givenMember1, givenArticle2));
+
+        // when
+        articleLikeRepository.delete(articleLike);
+
+        // then
+        assertThat(articleLikeRepository.findById(articleLike.getId())).isEmpty();
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/articlelike/ArticleLikeRepositoryTest.java
@@ -1,8 +1,10 @@
 package org.nightdivers.kupica.domain.articlelike;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.nightdivers.kupica.domain.articlelike.ArticleLike.createAnonymousArticleLike;
 import static org.nightdivers.kupica.domain.articlelike.ArticleLike.createMemberArticleLike;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_IP_LIST;
 import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
 import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser1;
@@ -27,6 +29,7 @@ import org.nightdivers.kupica.domain.article.ArticleRepository;
 import org.nightdivers.kupica.domain.member.Member;
 import org.nightdivers.kupica.domain.member.MemberRepository;
 import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.springframework.data.domain.PageRequest;
 
 @RequiredArgsConstructor
 @RepositoryTest
@@ -44,6 +47,7 @@ class ArticleLikeRepositoryTest {
 
     Article givenArticle1;
     Article givenArticle2;
+    Article givenArticle3;
 
     ArticleLike givenArticleLike1;
     ArticleLike givenArticleLike2;
@@ -62,6 +66,7 @@ class ArticleLikeRepositoryTest {
 
         givenArticle1 = articleRepository.save(createTestMemberArticle1());
         givenArticle2 = articleRepository.save(createTestMemberArticle2());
+        givenArticle3 = articleRepository.save(createTestMemberArticle3());
 
         givenArticleLike1 = articleLikeRepository.save(createMemberArticleLike(givenMember1, givenArticle1));
         givenArticleLike2 = articleLikeRepository.save(createMemberArticleLike(givenMember1, givenArticle2));
@@ -146,6 +151,54 @@ class ArticleLikeRepositoryTest {
         assertThat(articleLikeList).isEmpty();
     }
 
+    @DisplayName("좋아요 수가 많은 순서로 조회 - [성공]")
+    @Test
+    void whenFindArticleIdOrderByCountDesc_thenReturnsArticleLikeList() {
+        // given
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size())
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle1)));
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size() - 1)
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle2)));
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size() - 2)
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle3)));
+
+        // when
+        List<ArticleLike> actualArticleLikes = articleLikeRepository.findArticleIdOrderByCountDesc(
+                PageRequest.of(0, 10))
+                .getContent();
+        // then
+        assertAll(
+                () -> assertThat(actualArticleLikes.getFirst().getArticle().getId()).isEqualTo(givenArticle1.getId()),
+                () -> assertThat(actualArticleLikes.get(1).getArticle().getId()).isEqualTo(givenArticle2.getId()),
+                () -> assertThat(actualArticleLikes.get(2).getArticle().getId()).isEqualTo(givenArticle3.getId())
+        );
+    }
+
+    @DisplayName("좋아요 수가 적은 순서로 조회 - [성공]")
+    @Test
+    void whenFindArticleIdOrderByCountAsc_thenReturnsArticleLikeList() {
+        // given
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size())
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle1)));
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-1)
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle2)));
+        TEST_ANONYMOUS_IP_LIST.subList(0, TEST_ANONYMOUS_IP_LIST.size()-2)
+                .forEach(ip -> articleLikeRepository.save(createAnonymousArticleLike(ip, givenArticle3)));
+
+
+        // when
+        List<ArticleLike> actualArticleLikes = articleLikeRepository.findArticleIdOrderByCountAsc(
+                PageRequest.of(0, 10))
+                .getContent();
+
+        // then
+        assertAll(
+                () -> assertThat(actualArticleLikes.getLast().getArticle().getId()).isEqualTo(givenArticle1.getId()),
+                () -> assertThat(actualArticleLikes.get(actualArticleLikes.size()-2).getArticle().getId()).isEqualTo(givenArticle2.getId()),
+                () -> assertThat(actualArticleLikes.get(actualArticleLikes.size()-3).getArticle().getId()).isEqualTo(givenArticle3.getId())
+        );
+    }
+
 
     /* 좋아요 생성 */
     @DisplayName("member 좋아요 생성 - [성공]")
@@ -187,5 +240,31 @@ class ArticleLikeRepositoryTest {
 
         // then
         assertThat(articleLikeRepository.findById(articleLike.getId())).isEmpty();
+    }
+
+
+    /* 좋아요 수 조회 */
+    @DisplayName("article id 와 일치하는 좋아요 수 조회 - [성공]")
+    @Test
+    void givenArticleId_whenCountByArticleId_thenReturnsCount() {
+        // given
+
+        // when
+        Long count = articleLikeRepository.countByArticleId(givenArticle1.getId());
+
+        // then
+        assertThat(count).isEqualTo(3);
+    }
+
+    @DisplayName("article id 와 일치하는 좋아요 수 조회 - [실패 : 유효하지 않은 article id]")
+    @Test
+    void givenInvalidArticleId_whenCountByArticleId_thenReturnsZero() {
+        // given
+
+        // when
+        Long count = articleLikeRepository.countByArticleId(TEST_INVALID_ARTICLE_ID);
+
+        // then
+        assertThat(count).isZero();
     }
 }

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/comment/CommentRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/comment/CommentRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_NICKNAME;
 import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_ANONYMOUS_ARTICLE_1_CAPTION;
 import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
-import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_INVALID_COMMENT_ID;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_NICKNAME;
 import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser1;
@@ -20,7 +19,6 @@ import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMe
 import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMemberReplyComment3;
 import static org.nightdivers.kupica.support.factory.MemberFactory.createTestMember1;
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +39,6 @@ class CommentRepositoryTest {
     private final MemberRepository memberRepository;
     private final AnonymousUserRepository anonymousUserRepository;
     private final ArticleRepository articleRepository;
-    private final EntityManager entityManager;
 
     Member givenMember1;
 

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/comment/CommentRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/comment/CommentRepositoryTest.java
@@ -1,0 +1,432 @@
+package org.nightdivers.kupica.domain.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_INVALID_ANONYMOUS_USER_NICKNAME;
+import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_ANONYMOUS_ARTICLE_1_CAPTION;
+import static org.nightdivers.kupica.support.constant.ArticleConstant.TEST_INVALID_ARTICLE_ID;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_INVALID_COMMENT_ID;
+import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
+import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_NICKNAME;
+import static org.nightdivers.kupica.support.factory.AnonymousUserFactory.createTestAnonymousUser1;
+import static org.nightdivers.kupica.support.factory.ArticleFactory.createCustomAnonymousArticle;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestAnonymousComment1;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestAnonymousReplyComment1;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestAnonymousReplyComment2;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestAnonymousReplyComment3;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMemberComment1;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMemberReplyComment1;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMemberReplyComment2;
+import static org.nightdivers.kupica.support.factory.CommentFactory.createTestMemberReplyComment3;
+import static org.nightdivers.kupica.support.factory.MemberFactory.createTestMember1;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUserRepository;
+import org.nightdivers.kupica.domain.article.Article;
+import org.nightdivers.kupica.domain.article.ArticleRepository;
+import org.nightdivers.kupica.domain.member.Member;
+import org.nightdivers.kupica.domain.member.MemberRepository;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class CommentRepositoryTest {
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final AnonymousUserRepository anonymousUserRepository;
+    private final ArticleRepository articleRepository;
+    private final EntityManager entityManager;
+
+    Member givenMember1;
+
+    AnonymousUser givenAnonymousUser1;
+
+    Article givenAnonymousArticle1;
+
+    Comment givenMemberComment1;
+    Comment givenAnonymousComment1;
+
+    Comment givenMemberReplyComment1;
+    Comment givenMemberReplyComment2;
+    Comment givenMemberReplyComment3;
+
+    Comment givenAnonymousReplyComment1;
+    Comment givenAnonymousReplyComment2;
+    Comment givenAnonymousReplyComment3;
+
+    @BeforeEach
+    void setUp() {
+        givenMember1 = memberRepository.save(createTestMember1());
+        givenAnonymousUser1 = anonymousUserRepository.save(createTestAnonymousUser1());
+        givenAnonymousArticle1 = articleRepository.save(createCustomAnonymousArticle(TEST_ANONYMOUS_ARTICLE_1_CAPTION, givenAnonymousUser1));
+        givenMemberComment1 = commentRepository.save(createTestMemberComment1(givenMember1, givenAnonymousArticle1));
+        givenAnonymousComment1 = commentRepository.save(createTestAnonymousComment1(givenAnonymousUser1, givenAnonymousArticle1));
+        givenMemberReplyComment1 = commentRepository.save(createTestMemberReplyComment1(givenMemberComment1, givenMember1, givenAnonymousArticle1));
+        givenMemberReplyComment2 = commentRepository.save(createTestMemberReplyComment2(givenMemberComment1, givenMember1, givenAnonymousArticle1));
+        givenMemberReplyComment3 = commentRepository.save(createTestMemberReplyComment3(givenMemberComment1, givenMember1, givenAnonymousArticle1));
+        givenAnonymousReplyComment1 = commentRepository.save(createTestAnonymousReplyComment1(givenAnonymousComment1, givenAnonymousUser1, givenAnonymousArticle1));
+        givenAnonymousReplyComment2 = commentRepository.save(createTestAnonymousReplyComment2(givenAnonymousComment1, givenAnonymousUser1, givenAnonymousArticle1));
+        givenAnonymousReplyComment3 = commentRepository.save(createTestAnonymousReplyComment3(givenAnonymousComment1, givenAnonymousUser1, givenAnonymousArticle1));
+    }
+
+    /* 댓글 조회 */
+    @DisplayName("게시글 id 와 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenArticleId_whenFindAllByArticleId_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleId(givenAnonymousArticle1.getId());
+
+        // then
+        assertThat(comments).contains(
+                givenMemberComment1,
+                givenAnonymousComment1,
+                givenMemberReplyComment1,
+                givenMemberReplyComment2,
+                givenMemberReplyComment3,
+                givenAnonymousReplyComment1,
+                givenAnonymousReplyComment2,
+                givenAnonymousReplyComment3
+        );
+    }
+    // 시간, 대댓글, 쓴이
+
+    @DisplayName("member id 와 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenMemberId_whenFindAllByMemberId_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByMemberId(givenMember1.getId());
+
+        // then
+        assertThat(comments).contains(
+                givenMemberComment1,
+                givenMemberReplyComment1,
+                givenMemberReplyComment2,
+                givenMemberReplyComment3
+        );
+    }
+
+    @DisplayName("member id 와 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 member id]")
+    @Test
+    void givenInvalidMemberId_whenFindAllByMemberId_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByMemberId(TEST_INVALID_MEMBER_ID);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("member nickname 과 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenMemberNickname_whenFindAllByMemberNickname_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByMemberNickname(givenMember1.getNickname());
+
+        // then
+        assertThat(comments).contains(
+                givenMemberComment1,
+                givenMemberReplyComment1,
+                givenMemberReplyComment2,
+                givenMemberReplyComment3
+        );
+    }
+
+    @DisplayName("member nickname 과 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 member nickname]")
+    @Test
+    void givenInvalidMemberNickname_whenFindAllByMemberNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByMemberNickname(TEST_INVALID_MEMBER_NICKNAME);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하며 member nickname 과도 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenArticleIdAndMemberNickname_whenFindAllByArticleIdAndMemberNickname_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberNickname(givenAnonymousArticle1.getId(), givenMember1.getNickname());
+
+        // then
+        assertThat(comments).contains(
+                givenMemberComment1,
+                givenMemberReplyComment1,
+                givenMemberReplyComment2,
+                givenMemberReplyComment3
+        );
+    }
+
+    @DisplayName("article id 와 일치하며 member nickname 과도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 article id]")
+    @Test
+    void givenInvalidArticleIdAndMemberNickname_whenFindAllByArticleIdAndMemberNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberNickname(TEST_INVALID_ARTICLE_ID, givenMember1.getNickname());
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하며 member nickname 과도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 member nickname]")
+    @Test
+    void givenArticleIdAndInvalidMemberNickname_whenFindAllByArticleIdAndMemberNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberNickname(givenAnonymousArticle1.getId(), TEST_INVALID_MEMBER_NICKNAME);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("anonymous nickname 과 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenAnonymousUserNickname_whenFindAllByAnonymousUserNickname_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByAnonymousUserNickname(givenAnonymousUser1.getNickname());
+
+        // then
+        assertThat(comments).contains(
+                givenAnonymousComment1,
+                givenAnonymousReplyComment1,
+                givenAnonymousReplyComment2,
+                givenAnonymousReplyComment3
+        );
+    }
+
+    @DisplayName("anonymous nickname 과 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 anonymous nickname]")
+    @Test
+    void givenInvalidAnonymousUserNickname_whenFindAllByAnonymousUserNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByAnonymousUserNickname(TEST_INVALID_ANONYMOUS_USER_NICKNAME);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+
+    @DisplayName("article id 와 일치하며 member id 와도 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenArticleIdAndMemberId_whenFindAllByArticleIdAndMemberId_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberId(givenAnonymousArticle1.getId(), givenMember1.getId());
+
+        // then
+        assertThat(comments).contains(
+                givenMemberComment1,
+                givenMemberReplyComment1,
+                givenMemberReplyComment2,
+                givenMemberReplyComment3
+        );
+    }
+
+    @DisplayName("article id 와 일치하며 member id 와도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 article id]")
+    @Test
+    void givenInvalidArticleIdAndMemberId_whenFindAllByArticleIdAndMemberId_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberId(TEST_INVALID_ARTICLE_ID, givenMember1.getId());
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하며 member id 와도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 member id]")
+    @Test
+    void givenArticleIdAndInvalidMemberId_whenFindAllByArticleIdAndMemberId_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndMemberId(givenAnonymousArticle1.getId(), TEST_INVALID_MEMBER_ID);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하며 anonymous nickname 과도 일치하는 댓글 전체 조회 - [성공]")
+    @Test
+    void givenArticleIdAndAnonymousUserNickname_whenFindAllByArticleIdAndAnonymousUserNickname_thenCommentList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndAnonymousUserNickname(givenAnonymousArticle1.getId(), givenAnonymousUser1.getNickname());
+
+        // then
+        assertThat(comments).contains(
+                givenAnonymousComment1,
+                givenAnonymousReplyComment1,
+                givenAnonymousReplyComment2,
+                givenAnonymousReplyComment3
+        );
+    }
+
+    @DisplayName("article id 와 일치하며 anonymous nickname 과도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 article id]")
+    @Test
+    void givenInvalidArticleIdAndAnonymousUserNickname_whenFindAllByArticleIdAndAnonymousUserNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndAnonymousUserNickname(TEST_INVALID_ARTICLE_ID, givenAnonymousUser1.getNickname());
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+
+    @DisplayName("article id 와 일치하며 anonymous nickname 과도 일치하는 댓글 전체 조회 - [실패 : 존재하지 않는 anonymous nickname]")
+    @Test
+    void givenArticleIdAndInvalidAnonymousUserNickname_whenFindAllByArticleIdAndAnonymousUserNickname_thenEmptyList() {
+        // given
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleIdAndAnonymousUserNickname(givenAnonymousArticle1.getId(), TEST_INVALID_ANONYMOUS_USER_NICKNAME);
+
+        // then
+        assertThat(comments).isEmpty();
+    }
+    
+    
+    /* 댓글 생성 */
+    @DisplayName("member 댓글 생성 - [성공]")
+    @Test
+    void givenMember_whenSave_thenComment() {
+        // given
+
+        // when
+        Comment comment = commentRepository.save(createTestMemberComment1(givenMember1, givenAnonymousArticle1));
+
+        // then
+        assertAll(
+                () -> assertThat(comment).isNotNull(),
+                () -> assertThat(comment.getMember()).isEqualTo(givenMember1),
+                () -> assertThat(comment.getArticle()).isEqualTo(givenAnonymousArticle1)
+        );
+    }
+
+    @DisplayName("anonymous 댓글 생성 - [성공]")
+    @Test
+    void givenAnonymousUser_whenSave_thenComment() {
+        // given
+        AnonymousUser anonymousUser = anonymousUserRepository.save(createTestAnonymousUser1());
+        Article article = articleRepository.save(createCustomAnonymousArticle(TEST_ANONYMOUS_ARTICLE_1_CAPTION, givenAnonymousUser1));
+
+        // when
+        Comment comment = commentRepository.save(createTestAnonymousComment1(anonymousUser, article));
+
+        // then
+        assertAll(
+                () -> assertThat(comment).isNotNull(),
+                () -> assertThat(comment.getAnonymousUser()).isEqualTo(anonymousUser),
+                () -> assertThat(comment.getArticle()).isEqualTo(article)
+        );
+    }
+
+    @DisplayName("member 대댓글 생성 - [성공]")
+    @Test
+    void givenParentCommentAndMember_whenSave_thenComment() {
+        // given
+
+        // when
+        Comment comment = commentRepository.save(createTestMemberReplyComment1(givenMemberComment1, givenMember1, givenAnonymousArticle1));
+
+        // then
+        assertAll(
+                () -> assertThat(comment).isNotNull(),
+                () -> assertThat(comment.getMember()).isEqualTo(givenMember1),
+                () -> assertThat(comment.getArticle()).isEqualTo(givenAnonymousArticle1),
+                () -> assertThat(comment.getReplyTargetComment()).isEqualTo(givenMemberComment1)
+        );
+    }
+
+    @DisplayName("anonymous 대댓글 생성 - [성공]")
+    @Test
+    void givenParentCommentAndAnonymousUser_whenSave_thenComment() {
+        // given
+        AnonymousUser anonymousUser = anonymousUserRepository.save(createTestAnonymousUser1());
+        Article article = articleRepository.save(createCustomAnonymousArticle(TEST_ANONYMOUS_ARTICLE_1_CAPTION, givenAnonymousUser1));
+
+        // when
+        Comment comment = commentRepository.save(createTestAnonymousReplyComment1(givenAnonymousComment1, anonymousUser, article));
+
+        // then
+        assertAll(
+                () -> assertThat(comment).isNotNull(),
+                () -> assertThat(comment.getAnonymousUser()).isEqualTo(anonymousUser),
+                () -> assertThat(comment.getArticle()).isEqualTo(article),
+                () -> assertThat(comment.getReplyTargetComment()).isEqualTo(givenAnonymousComment1)
+        );
+    }
+
+
+    /* 댓글 수정 */
+    @DisplayName("댓글 수정 - [성공]")
+    @Test
+    void givenComment_whenUpdate_thenComment() {
+        // given
+        String updatedContent = "Updated content";
+
+        // when
+        givenMemberComment1.changeContent(updatedContent);
+        Comment updatedComment = commentRepository.save(givenMemberComment1);
+
+        // then
+        assertThat(updatedComment.getContent()).isEqualTo(updatedContent);
+    }
+
+    @DisplayName("대댓글 수정 - [성공]")
+    @Test
+    void givenReplyComment_whenUpdate_thenComment() {
+        // given
+        Long prevParentCommentId = givenMemberReplyComment1.getReplyTargetComment().getId();
+        String updatedContent = "Updated content";
+
+        // when
+        givenMemberReplyComment1.changeContent(updatedContent);
+        Comment updatedComment = commentRepository.save(givenMemberReplyComment1);
+
+
+        // then
+        assertAll(
+                () -> assertThat(updatedComment.getReplyTargetComment().getId()).isEqualTo(prevParentCommentId),
+                () -> assertThat(updatedComment.getContent()).isEqualTo(updatedContent)
+        );
+    }
+
+
+    /* 댓글 삭제 */
+    @DisplayName("댓글 삭제 - [성공]")
+    @Test
+    void givenComment_whenDelete_thenComment() {
+        // given
+
+        // when
+        commentRepository.delete(givenMemberComment1);
+
+        // then
+        assertThat(commentRepository.findById(givenMemberComment1.getId())).isEmpty();
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/hashtag/HashtagRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/hashtag/HashtagRepositoryTest.java
@@ -1,0 +1,144 @@
+package org.nightdivers.kupica.domain.hashtag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_INVALID_HASHTAG_ID;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_TAG_NAME_1;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_TAG_NAME_2;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_TAG_NAME_3;
+import static org.nightdivers.kupica.support.constant.HashtagConstant.TEST_TAG_NAME_4;
+
+import jakarta.persistence.EntityManager;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.domain.article.Article;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.nightdivers.kupica.support.factory.ArticleFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class HashtagRepositoryTest {
+    private final HashtagRepository hashtagRepository;
+    private final EntityManager entityManager;
+
+    Article givenArticle;
+
+    Hashtag givenHashtag1;
+    Hashtag givenHashtag2;
+    Hashtag givenHashtag3;
+
+    @BeforeEach
+    void setUp() {
+        givenArticle = ArticleFactory.createTestAnonymousArticle1();
+
+        givenHashtag1 = hashtagRepository.save(Hashtag.of(TEST_TAG_NAME_1));
+        givenHashtag2 = hashtagRepository.save(Hashtag.of(TEST_TAG_NAME_2));
+        givenHashtag3 = hashtagRepository.save(Hashtag.of(TEST_TAG_NAME_3));
+    }
+
+    /* Hashtag 조회 */
+    @DisplayName("해시태그 조회 - [성공]")
+    @Test
+    void givenHashtag_whenFindById_thenSuccess() {
+        // given
+
+        // when
+        Hashtag actualHashtag = hashtagRepository.findById(givenHashtag1.getId()).orElseThrow(NoSuchElementException::new);
+
+        // then
+        assertThat(actualHashtag).isEqualTo(givenHashtag1);
+    }
+
+    @DisplayName("해시태그 조회 - [실패 : 존재하지 않는 ID]")
+    @Test
+    void givenInvalidHashtagId_whenFindById_thenFail() {
+        // given
+
+        // when & then
+        assertThatThrownBy(() -> hashtagRepository.findById(TEST_INVALID_HASHTAG_ID).orElseThrow(NoSuchElementException::new))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @DisplayName("해시태그 전체 조회 - [성공]")
+    @Test
+    void givenHashtags_whenFindAll_thenSuccess() {
+        // given
+
+        // when
+        Iterable<Hashtag> actualHashtags = hashtagRepository.findAll();
+
+        // then
+        assertThat(actualHashtags).contains(givenHashtag1, givenHashtag2, givenHashtag3);
+    }
+
+
+    /* Hashtag 생성 */
+    @DisplayName("해시태그 생성 - [성공]")
+    @Test
+    void givenHashtag_whenSave_thenSuccess() {
+        // given
+        Hashtag expectedHashtag = Hashtag.of(TEST_TAG_NAME_4);
+
+        // when
+        Hashtag actualHashtag = hashtagRepository.save(expectedHashtag);
+
+        // then
+        assertThat(actualHashtag).isEqualTo(expectedHashtag);
+    }
+
+    @DisplayName("해시태그 생성 - [실패 : 중복된 태그명]")
+    @Test
+    void givenHashtag_whenSave_thenThrowDataIntegrityViolationException() {
+        // given
+        Hashtag expectedHashtag = Hashtag.of(TEST_TAG_NAME_1);
+
+        // when & then
+        assertThatThrownBy(() -> hashtagRepository.save(expectedHashtag))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+
+    /* Hashtag 수정 */
+    @DisplayName("해시태그 수정 - [성공]")
+    @Test
+    void givenHashtag_whenUpdate_thenSuccess() {
+        // given
+
+        // when
+        givenHashtag1.changeTagName(TEST_TAG_NAME_4);
+        Hashtag actualHashtag = hashtagRepository.findById(givenHashtag1.getId()).orElseThrow(NoSuchElementException::new);
+
+        // then
+        assertThat(actualHashtag.getTagName()).isEqualTo(TEST_TAG_NAME_4);
+    }
+
+    @DisplayName("해시태그 수정 - [실패 : 중복된 태그명]")
+    @Test
+    void givenHashtag_whenUpdate_thenThrowConstraintViolationException() {
+        // given
+        givenHashtag1.changeTagName(TEST_TAG_NAME_2);
+
+        // when & then
+        assertThatThrownBy(entityManager::flush)
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+
+    /* Hashtag 삭제 */
+    @DisplayName("해시태그 삭제 - [성공]")
+    @Test
+    void givenHashtag_whenDelete_thenSuccess() {
+        // given
+
+        // when
+        hashtagRepository.deleteById(givenHashtag1.getId());
+
+        // then
+        assertThat(hashtagRepository.findAll()).doesNotContain(givenHashtag1);
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/hashtag/HashtagValidatorTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/hashtag/HashtagValidatorTest.java
@@ -1,0 +1,106 @@
+package org.nightdivers.kupica.domain.hashtag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HashtagValidatorTest {
+
+    /* Hashtag validateTagName Test */
+    @DisplayName("# 가 앞에 붙지 않은 tagname 이 주어지면 #를 붙여서 반환한다.")
+    @Test
+    void givenTagNameWithoutHash_whenValidateTagName_thenAddHash() {
+        // given
+        String givenTagName = "test tag name";
+
+        // when
+        Hashtag actual = Hashtag.of(givenTagName);
+
+        // then
+        assertThat(actual.getTagName()).isEqualTo("#" + givenTagName);
+    }
+
+    @DisplayName("# 가 앞에 붙은 tagname 이 주어지면 그대로 반환한다.")
+    @Test
+    void givenTagNameWithHash_whenValidateTagName_thenReturnAsItIs() {
+        // given
+        String givenTagName = "#test tag name";
+
+        // when
+        Hashtag actual = Hashtag.of(givenTagName);
+
+        // then
+        assertThat(actual.getTagName()).isEqualTo(givenTagName);
+    }
+
+    @DisplayName("tagname 이 null 이거나 빈 문자열이면 IllegalArgumentException 을 던진다.")
+    @Test
+    void givenEmptyTagName_whenValidateTagName_thenThrowIllegalArgumentException() {
+        // given
+        String givenEmptyTagName = "";
+        String givenNullTagName = null;
+
+        // when & then
+        assertAll(
+                () -> assertThatThrownBy(() -> Hashtag.of(givenEmptyTagName))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Tag name must not be empty"),
+                () -> assertThatThrownBy(() -> Hashtag.of(givenNullTagName))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Tag name must not be empty")
+        );
+    }
+
+    @DisplayName("tagname 앞에 # 이 2개 이상 붙을 경우 #을 1개로 줄여서 반환한다.")
+    @Test
+    void givenTagNameWithMultipleHash_whenValidateTagName_thenReduceHash() {
+        // given
+        String givenTagName = "##test tag name";
+
+        // when
+        Hashtag actual = Hashtag.of(givenTagName);
+
+        // then
+        assertThat(actual.getTagName()).isEqualTo("#test tag name");
+    }
+
+    @DisplayName("tagname 이 #으로만 이루어졌다면 예외를 반환한다.")
+    @Test
+    void givenTagNameWithOnlyHash_whenValidateTagName_thenThrowIllegalArgumentException() {
+        // given
+        String givenTagName = "######";
+
+        // when & then
+        assertThatThrownBy(() -> Hashtag.of(givenTagName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Tag name must not be empty");
+    }
+
+    @DisplayName("tagname 이 26자를 초과하면 예외를 반환한다.")
+    @Test
+    void givenTagNameExceeding26Characters_whenValidateTagName_thenThrowIllegalArgumentException() {
+        // given
+        String givenTagName = "test tag name test tag name test tag name";
+
+        // when & then
+        assertThatThrownBy(() -> Hashtag.of(givenTagName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Tag name must not exceed 26 characters");
+    }
+
+    @DisplayName("# 이 tagname 중간에 있는건 tagname 의 일부러 판단한다.")
+    @Test
+    void givenTagNameWithHashInTheMiddle_whenValidateTagName_thenReturnAsItIs() {
+        // given
+        String givenTagName = "test #tag name";
+
+        // when
+        Hashtag actual = Hashtag.of(givenTagName);
+
+        // then
+        assertThat(actual.getTagName()).isEqualTo("#" + givenTagName);
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/member/MemberRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/member/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package org.nightdivers.kupica.domain.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_EMAIL;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_ID;
 import static org.nightdivers.kupica.support.constant.MemberConstant.TEST_INVALID_MEMBER_NICKNAME;
@@ -193,9 +194,11 @@ class MemberRepositoryTest {
         Member actual = memberRepository.findById(prevMember.getId()).orElseThrow(NoSuchElementException::new);
 
         // then
-        assertThat(actual).isEqualTo(prevMember);
-        assertThat(actual.getNickname()).isEqualTo("newNickname");
-        assertThat(actual.getUpdatedDatetime()).isNotEqualTo(prevUpdatedDatetime);
+        assertAll(
+            () -> assertThat(actual).isEqualTo(prevMember),
+            () -> assertThat(actual.getNickname()).isEqualTo("newNickname"),
+            () -> assertThat(actual.getUpdatedDatetime()).isNotEqualTo(prevUpdatedDatetime)
+        );
     }
 
     @DisplayName("회원 닉네임 수정 - [실패 : 중복된 nickname]")

--- a/kupica/src/test/java/org/nightdivers/kupica/domain/photodownloadsource/PhotoDownloadSourceRepositoryTest.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/domain/photodownloadsource/PhotoDownloadSourceRepositoryTest.java
@@ -1,0 +1,42 @@
+package org.nightdivers.kupica.domain.photodownloadsource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nightdivers.kupica.support.annotation.RepositoryTest;
+import org.springframework.data.domain.PageRequest;
+
+@RequiredArgsConstructor
+@RepositoryTest
+class PhotoDownloadSourceRepositoryTest {
+    private final PhotoDownloadSourceRepository photoDownloadSourceRepository;
+
+    /* PhotoDownloadSource 조회 */
+    @DisplayName("article id 와 일치하는 PhotoDownloadSource 전체 조회 - [성공]")
+    @Test
+    void givenArticleId_whenFindPhotoDownloadSourceByArticleId_thenReturnPhotoDownloadSource() {
+        // given
+
+        // when
+        List<PhotoDownloadSource> photoDownloadSources = photoDownloadSourceRepository.findByArticleId(1L);
+
+        // then
+        assertThat(photoDownloadSources).isNotEmpty();
+    }
+
+    @DisplayName("article id 와 일치하는 PhotoDownloadSource 페이징 조회 - [성공]")
+    @Test
+    void givenArticleId_whenFindPhotoDownloadSourceByArticleId_thenReturnPhotoDownloadSourcePage() {
+        // given
+
+        // when
+        List<PhotoDownloadSource> photoDownloadSources = photoDownloadSourceRepository.findByArticleId(PageRequest.of(0, 5), 1L).getContent();
+
+        // then
+        assertThat(photoDownloadSources).isNotEmpty();
+    }
+
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
@@ -1,0 +1,32 @@
+package org.nightdivers.kupica.support.constant;
+
+import org.nightdivers.kupica.domain.member.UserRole;
+
+public class AnonymousUserConstant {
+    public static final int DUPLICATED_TEST_ANONYMOUS_COUNT = 3;
+
+    public static final String TEST_ANONYMOUS_USER_1_NICKNAME = "anonymous user 1";
+    public static final String TEST_ANONYMOUS_USER_1_PASSWORD = "3BpZO23LrjDC423agmoxiB$04$I5";
+    public static final String TEST_ANONYMOUS_USER_1_IP_ADDRESS = "245.108.203.138/9";
+    public static final UserRole TEST_ANONYMOUS_USER_1_ROLE = UserRole.ANONYMOUS;
+
+    public static final String TEST_ANONYMOUS_USER_2_NICKNAME = "anonymous user 2";
+    public static final String TEST_ANONYMOUS_USER_2_PASSWORD = "aZOL532rjDC$04$IBpCgrjxgmiBvcvox";
+    public static final String TEST_ANONYMOUS_USER_2_IP_ADDRESS = "97.82.201.19/27";
+    public static final UserRole TEST_ANONYMOUS_USER_2_ROLE = UserRole.ANONYMOUS;
+
+    public static final String TEST_ANONYMOUS_USER_3_NICKNAME = "anonymous user 3";
+    public static final String TEST_ANONYMOUS_USER_3_PASSWORD = "a$04$IBpfdssZDCgmi53rjxfdfdf";
+    public static final String TEST_ANONYMOUS_USER_3_IP_ADDRESS = "35.207.94.236/3";
+    public static final UserRole TEST_ANONYMOUS_USER_3_ROLE = UserRole.ANONYMOUS;
+
+    public static final String TEST_ANONYMOUS_USER_4_NICKNAME = "anonymous user 4";
+    public static final String TEST_ANONYMOUS_USER_4_PASSWORD = "4$a$0Imi53BpfdssZDfdfdf3fdsxc";
+    public static final String TEST_ANONYMOUS_USER_4_IP_ADDRESS = "135.217.236.94/13";
+    public static final UserRole TEST_ANONYMOUS_USER_4_ROLE = UserRole.ANONYMOUS;
+
+    public static final Long TEST_INVALID_ANONYMOUS_USER_ID = -1L;
+    public static final String TEST_INVALID_ANONYMOUS_USER_NICKNAME = "invalid nickname";
+    public static final String TEST_INVALID_ANONYMOUS_USER_PASSWORD = "invalid password";
+    public static final String TEST_INVALID_ANONYMOUS_USER_IP_ADDRESS = "invalid ip address";
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
@@ -6,27 +6,27 @@ public class AnonymousUserConstant {
     public static final int DUPLICATED_TEST_ANONYMOUS_COUNT = 3;
 
     public static final String TEST_ANONYMOUS_USER_1_NICKNAME = "anonymous user 1";
-    public static final String TEST_ANONYMOUS_USER_1_PASSWORD = "3BpZO23LrjDC423agmoxiB$04$I5";
+    public static final String TEST_ANONYMOUS_USER_1_PW = "3BpZO23LrjDC423agmoxiB$04$I5";
     public static final String TEST_ANONYMOUS_USER_1_IP_ADDRESS = "245.108.203.138/9";
     public static final UserRole TEST_ANONYMOUS_USER_1_ROLE = UserRole.ANONYMOUS;
 
     public static final String TEST_ANONYMOUS_USER_2_NICKNAME = "anonymous user 2";
-    public static final String TEST_ANONYMOUS_USER_2_PASSWORD = "aZOL532rjDC$04$IBpCgrjxgmiBvcvox";
+    public static final String TEST_ANONYMOUS_USER_2_PW = "aZOL532rjDC$04$IBpCgrjxgmiBvcvox";
     public static final String TEST_ANONYMOUS_USER_2_IP_ADDRESS = "97.82.201.19/27";
     public static final UserRole TEST_ANONYMOUS_USER_2_ROLE = UserRole.ANONYMOUS;
 
     public static final String TEST_ANONYMOUS_USER_3_NICKNAME = "anonymous user 3";
-    public static final String TEST_ANONYMOUS_USER_3_PASSWORD = "a$04$IBpfdssZDCgmi53rjxfdfdf";
+    public static final String TEST_ANONYMOUS_USER_3_PW = "a$04$IBpfdssZDCgmi53rjxfdfdf";
     public static final String TEST_ANONYMOUS_USER_3_IP_ADDRESS = "35.207.94.236/3";
     public static final UserRole TEST_ANONYMOUS_USER_3_ROLE = UserRole.ANONYMOUS;
 
     public static final String TEST_ANONYMOUS_USER_4_NICKNAME = "anonymous user 4";
-    public static final String TEST_ANONYMOUS_USER_4_PASSWORD = "4$a$0Imi53BpfdssZDfdfdf3fdsxc";
+    public static final String TEST_ANONYMOUS_USER_4_PW = "4$a$0Imi53BpfdssZDfdfdf3fdsxc";
     public static final String TEST_ANONYMOUS_USER_4_IP_ADDRESS = "135.217.236.94/13";
     public static final UserRole TEST_ANONYMOUS_USER_4_ROLE = UserRole.ANONYMOUS;
 
     public static final Long TEST_INVALID_ANONYMOUS_USER_ID = -1L;
     public static final String TEST_INVALID_ANONYMOUS_USER_NICKNAME = "invalid nickname";
-    public static final String TEST_INVALID_ANONYMOUS_USER_PASSWORD = "invalid password";
+    public static final String TEST_INVALID_ANONYMOUS_USER_PW = "invalid password";
     public static final String TEST_INVALID_ANONYMOUS_USER_IP_ADDRESS = "invalid ip address";
 }

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/AnonymousUserConstant.java
@@ -1,5 +1,6 @@
 package org.nightdivers.kupica.support.constant;
 
+import java.util.List;
 import org.nightdivers.kupica.domain.member.UserRole;
 
 public class AnonymousUserConstant {
@@ -29,4 +30,9 @@ public class AnonymousUserConstant {
     public static final String TEST_INVALID_ANONYMOUS_USER_NICKNAME = "invalid nickname";
     public static final String TEST_INVALID_ANONYMOUS_USER_PW = "invalid password";
     public static final String TEST_INVALID_ANONYMOUS_USER_IP_ADDRESS = "invalid ip address";
+
+    public static final List<String> TEST_ANONYMOUS_IP_LIST = List.of(
+            "169.81.95.209", "1.6.233.180", "49.69.156.152", "19.215.137.130", "148.87.86.200",
+            "92.36.8.110", "116.58.68.172", "247.41.225.160", "147.56.170.133", "28.188.117.88"
+    );
 }

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/ArticleConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/ArticleConstant.java
@@ -1,0 +1,22 @@
+package org.nightdivers.kupica.support.constant;
+
+public class ArticleConstant {
+    public static final String TEST_MEMBER_ARTICLE_1_CAPTION = "test member 1 caption";
+
+    public static final String TEST_MEMBER_ARTICLE_2_CAPTION = "test member 2 caption";
+
+    public static final String TEST_MEMBER_ARTICLE_3_CAPTION = "test member 3 caption";
+
+    public static final String TEST_MEMBER_ARTICLE_4_CAPTION = "test member 4 caption";
+
+    public static final String TEST_ANONYMOUS_ARTICLE_1_CAPTION = "test anonymous 1 caption";
+
+    public static final String TEST_ANONYMOUS_ARTICLE_2_CAPTION = "test anonymous 2 caption";
+
+    public static final String TEST_ANONYMOUS_ARTICLE_3_CAPTION = "test anonymous 3 caption";
+
+    public static final String TEST_ANONYMOUS_ARTICLE_4_CAPTION = "test anonymous 4 caption";
+
+    public static final Long TEST_INVALID_ARTICLE_ID = -1L;
+    public static final String TEST_INVALID_ARTICLE_CAPTION = "invalid caption";
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/CommentConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/CommentConstant.java
@@ -1,0 +1,17 @@
+package org.nightdivers.kupica.support.constant;
+
+public class CommentConstant {
+    public static final String TEST_MEMBER_COMMENT_CONTENT_1 = "Test member comment 1";
+
+    public static final String TEST_MEMBER_COMMENT_CONTENT_2 = "Test member comment 2";
+
+    public static final String TEST_MEMBER_COMMENT_CONTENT_3 = "Test member comment 3";
+
+    public static final String TEST_ANONYMOUS_COMMENT_CONTENT_1 = "Test anonymous comment 1";
+
+    public static final String TEST_ANONYMOUS_COMMENT_CONTENT_2 = "Test anonymous comment 2";
+
+    public static final String TEST_ANONYMOUS_COMMENT_CONTENT_3 = "Test anonymous comment 3";
+
+    public static final Long TEST_INVALID_COMMENT_ID = -1L;
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/constant/HashtagConstant.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/constant/HashtagConstant.java
@@ -1,0 +1,18 @@
+package org.nightdivers.kupica.support.constant;
+
+public class HashtagConstant {
+    public static final String TEST_TAG_NAME_1 = "#test1";
+    public static final String TEST_TAG_NAME_2 = "#test2";
+    public static final String TEST_TAG_NAME_3 = "#test3";
+    public static final String TEST_TAG_NAME_4 = "#test4";
+
+    public static final String TEST_TAG_NAME_1_UPDATE = "#test1_update";
+    public static final String TEST_TAG_NAME_2_UPDATE = "#test2_update";
+    public static final String TEST_TAG_NAME_3_UPDATE = "#test3_update";
+    public static final String TEST_TAG_NAME_4_UPDATE = "#test4_update";
+
+    public static final String TEST_VALID_TAG_NAME = "#SEJONG";
+
+    public static final Long TEST_INVALID_HASHTAG_ID = -1L;
+    public static final String TEST_INVALID_TAG_NAME = "###JONG";
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/factory/AnonymousUserFactory.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/factory/AnonymousUserFactory.java
@@ -1,0 +1,78 @@
+package org.nightdivers.kupica.support.factory;
+
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_ROLE;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_ROLE;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_ROLE;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_IP_ADDRESS;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_NICKNAME;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_ROLE;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.member.UserRole;
+
+public class AnonymousUserFactory {
+    public static AnonymousUser createTestAnonymousUser1() {
+        return AnonymousUser.of(
+                TEST_ANONYMOUS_USER_1_NICKNAME,
+                TEST_ANONYMOUS_USER_1_PASSWORD,
+                TEST_ANONYMOUS_USER_1_IP_ADDRESS,
+                TEST_ANONYMOUS_USER_1_ROLE
+        );
+    }
+
+    public static AnonymousUser createTestAnonymousUser2() {
+        return AnonymousUser.of(
+                TEST_ANONYMOUS_USER_2_NICKNAME,
+                TEST_ANONYMOUS_USER_2_PASSWORD,
+                TEST_ANONYMOUS_USER_2_IP_ADDRESS,
+                TEST_ANONYMOUS_USER_2_ROLE
+        );
+    }
+
+    public static AnonymousUser createTestAnonymousUser3() {
+        return AnonymousUser.of(
+                TEST_ANONYMOUS_USER_3_NICKNAME,
+                TEST_ANONYMOUS_USER_3_PASSWORD,
+                TEST_ANONYMOUS_USER_3_IP_ADDRESS,
+                TEST_ANONYMOUS_USER_3_ROLE
+        );
+    }
+
+    public static AnonymousUser createTestAnonymousUser4() {
+        return AnonymousUser.of(
+                TEST_ANONYMOUS_USER_4_NICKNAME,
+                TEST_ANONYMOUS_USER_4_PASSWORD,
+                TEST_ANONYMOUS_USER_4_IP_ADDRESS,
+                TEST_ANONYMOUS_USER_4_ROLE
+        );
+    }
+
+    public static List<AnonymousUser> createDuplicatedAnonymousUsers(Supplier<AnonymousUser> creatorMethod, int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> creatorMethod.get())
+                .collect(Collectors.toList());
+    }
+
+    public static AnonymousUser createCustomAnonymousUsers(String nickname, String password, String ipAddress) {
+        return AnonymousUser.of(
+                nickname,
+                password,
+                ipAddress,
+                UserRole.ANONYMOUS
+        );
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/factory/AnonymousUserFactory.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/factory/AnonymousUserFactory.java
@@ -2,19 +2,19 @@ package org.nightdivers.kupica.support.factory;
 
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_NICKNAME;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_PW;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_1_ROLE;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_NICKNAME;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_PW;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_2_ROLE;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_NICKNAME;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_PW;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_3_ROLE;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_IP_ADDRESS;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_NICKNAME;
-import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_PASSWORD;
+import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_PW;
 import static org.nightdivers.kupica.support.constant.AnonymousUserConstant.TEST_ANONYMOUS_USER_4_ROLE;
 
 import java.util.List;
@@ -28,7 +28,7 @@ public class AnonymousUserFactory {
     public static AnonymousUser createTestAnonymousUser1() {
         return AnonymousUser.of(
                 TEST_ANONYMOUS_USER_1_NICKNAME,
-                TEST_ANONYMOUS_USER_1_PASSWORD,
+                TEST_ANONYMOUS_USER_1_PW,
                 TEST_ANONYMOUS_USER_1_IP_ADDRESS,
                 TEST_ANONYMOUS_USER_1_ROLE
         );
@@ -37,7 +37,7 @@ public class AnonymousUserFactory {
     public static AnonymousUser createTestAnonymousUser2() {
         return AnonymousUser.of(
                 TEST_ANONYMOUS_USER_2_NICKNAME,
-                TEST_ANONYMOUS_USER_2_PASSWORD,
+                TEST_ANONYMOUS_USER_2_PW,
                 TEST_ANONYMOUS_USER_2_IP_ADDRESS,
                 TEST_ANONYMOUS_USER_2_ROLE
         );
@@ -46,7 +46,7 @@ public class AnonymousUserFactory {
     public static AnonymousUser createTestAnonymousUser3() {
         return AnonymousUser.of(
                 TEST_ANONYMOUS_USER_3_NICKNAME,
-                TEST_ANONYMOUS_USER_3_PASSWORD,
+                TEST_ANONYMOUS_USER_3_PW,
                 TEST_ANONYMOUS_USER_3_IP_ADDRESS,
                 TEST_ANONYMOUS_USER_3_ROLE
         );
@@ -55,7 +55,7 @@ public class AnonymousUserFactory {
     public static AnonymousUser createTestAnonymousUser4() {
         return AnonymousUser.of(
                 TEST_ANONYMOUS_USER_4_NICKNAME,
-                TEST_ANONYMOUS_USER_4_PASSWORD,
+                TEST_ANONYMOUS_USER_4_PW,
                 TEST_ANONYMOUS_USER_4_IP_ADDRESS,
                 TEST_ANONYMOUS_USER_4_ROLE
         );

--- a/kupica/src/test/java/org/nightdivers/kupica/support/factory/ArticleFactory.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/factory/ArticleFactory.java
@@ -1,0 +1,78 @@
+package org.nightdivers.kupica.support.factory;
+
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.article.Article;
+import org.nightdivers.kupica.domain.member.Member;
+import org.nightdivers.kupica.support.constant.ArticleConstant;
+
+public class ArticleFactory {
+    public static Article createTestMemberArticle1() {
+        return Article.createMemberArticle(
+                ArticleConstant.TEST_MEMBER_ARTICLE_1_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestMemberArticle2() {
+        return Article.createMemberArticle(
+                ArticleConstant.TEST_MEMBER_ARTICLE_2_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestMemberArticle3() {
+        return Article.createMemberArticle(
+                ArticleConstant.TEST_MEMBER_ARTICLE_3_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestMemberArticle4() {
+        return Article.createMemberArticle(
+                ArticleConstant.TEST_MEMBER_ARTICLE_4_CAPTION,
+                null
+        );
+    }
+
+    public static Article createCustomMemberArticle(String caption, Member member) {
+        return Article.createMemberArticle(
+                caption,
+                member
+        );
+    }
+
+    public static Article createTestAnonymousArticle1() {
+        return Article.createAnonymousArticle(
+                ArticleConstant.TEST_ANONYMOUS_ARTICLE_1_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestAnonymousArticle2() {
+        return Article.createAnonymousArticle(
+                ArticleConstant.TEST_ANONYMOUS_ARTICLE_2_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestAnonymousArticle3() {
+        return Article.createAnonymousArticle(
+                ArticleConstant.TEST_ANONYMOUS_ARTICLE_3_CAPTION,
+                null
+        );
+    }
+
+    public static Article createTestAnonymousArticle4() {
+        return Article.createAnonymousArticle(
+                ArticleConstant.TEST_ANONYMOUS_ARTICLE_4_CAPTION,
+                null
+        );
+    }
+
+    public static Article createCustomAnonymousArticle(String caption, AnonymousUser anonymousUser) {
+        return Article.createAnonymousArticle(
+                caption,
+                anonymousUser
+        );
+    }
+}

--- a/kupica/src/test/java/org/nightdivers/kupica/support/factory/CommentFactory.java
+++ b/kupica/src/test/java/org/nightdivers/kupica/support/factory/CommentFactory.java
@@ -1,0 +1,117 @@
+package org.nightdivers.kupica.support.factory;
+
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_ANONYMOUS_COMMENT_CONTENT_1;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_ANONYMOUS_COMMENT_CONTENT_2;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_ANONYMOUS_COMMENT_CONTENT_3;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_MEMBER_COMMENT_CONTENT_1;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_MEMBER_COMMENT_CONTENT_2;
+import static org.nightdivers.kupica.support.constant.CommentConstant.TEST_MEMBER_COMMENT_CONTENT_3;
+
+import org.nightdivers.kupica.domain.anonymoususer.AnonymousUser;
+import org.nightdivers.kupica.domain.article.Article;
+import org.nightdivers.kupica.domain.comment.Comment;
+import org.nightdivers.kupica.domain.member.Member;
+
+public class CommentFactory {
+    public static Comment createTestMemberComment1(Member member, Article memberArticle) {
+        return Comment.createMemberComment(
+                TEST_MEMBER_COMMENT_CONTENT_1,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestMemberComment2(Member member, Article memberArticle) {
+        return Comment.createMemberComment(
+                TEST_MEMBER_COMMENT_CONTENT_2,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestMemberComment3(Member member, Article memberArticle) {
+        return Comment.createMemberComment(
+                TEST_MEMBER_COMMENT_CONTENT_3,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestMemberReplyComment1(Comment parentComment, Member member, Article memberArticle) {
+        return Comment.createMemberReplyComment(
+                TEST_MEMBER_COMMENT_CONTENT_1,
+                parentComment,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestMemberReplyComment2(Comment parentComment, Member member, Article memberArticle) {
+        return Comment.createMemberReplyComment(
+                TEST_MEMBER_COMMENT_CONTENT_2,
+                parentComment,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestMemberReplyComment3(Comment parentComment, Member member, Article memberArticle) {
+        return Comment.createMemberReplyComment(
+                TEST_MEMBER_COMMENT_CONTENT_3,
+                parentComment,
+                member,
+                memberArticle
+        );
+    }
+
+    public static Comment createTestAnonymousComment1(AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousUserComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_1,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+
+    public static Comment createTestAnonymousComment2(AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousUserComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_2,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+
+    public static Comment createTestAnonymousComment3(AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousUserComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_3,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+
+    public static Comment createTestAnonymousReplyComment1(Comment parentComment, AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousReplyComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_1,
+                parentComment,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+
+    public static Comment createTestAnonymousReplyComment2(Comment parentComment, AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousReplyComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_2,
+                parentComment,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+
+    public static Comment createTestAnonymousReplyComment3(Comment parentComment, AnonymousUser anonymousUser, Article anonymousArticle) {
+        return Comment.createAnonymousReplyComment(
+                TEST_ANONYMOUS_COMMENT_CONTENT_3,
+                parentComment,
+                anonymousUser,
+                anonymousArticle
+        );
+    }
+}


### PR DESCRIPTION
### 개요
기존에 만든 Entity 클래스의 Repository 클래스와 그 테스트 코드를 작성한다.

### 작업내용

- [x] AnonymousUserRepository
- [x] ArticleRepository
- [x] CommentRepository
- [x] ArticleLikeRepository
- [x] HashtagRepository
- [x] ArticleHashtagRepository
- [x] PhotoDownloadSourceRepository

### 추가 고려 사항
MemberRepository 는 지난번에 작성했었다. #29 

`JpaRepository` 를 통해서 기본적으로 다 구현하였다.
초반 부에 작성한 Repository 테스트들은 `JpaRepository` 에서 기본적으로 제공해주는 메소드(find, save ...) 등의 테스트 코드를 작성하였지만 이미 `JpaRepository` 의 기본적인 메소드들은 충분히 검증이 되었기에 후반 부에 작성한 Repository 테스트에서는 직접 선언한 메소드가 아닌 이상 제외하였다.

로깅에 대한 부분을 아직 정하지 않아서 예외를 던져도 받아내는 코드를 작성하지 않았다. 추후에 로깅에 대한 부분을 정하고 난다면 이러한 부분을 보완할 예정이다.
